### PR TITLE
nullifier protocol

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,14 +1,10 @@
 # Cargo configuration for separate backend builds
 
 [alias]
-# Build commands
-build-risc0 = "build --target-dir target/risc0 --no-default-features --features risc0,testing"
-build-sp1 = "build --target-dir target/sp1 --no-default-features --features sp1,testing"
-build-mock = "build --target-dir target/mock --no-default-features --features mock,testing"
-
-# Release builds
-release-risc0 = "build --release --target-dir target/risc0 --no-default-features --features risc0,testing"
-release-sp1 = "build --release --target-dir target/sp1 --no-default-features --features sp1,testing"
+# Release builds (primary commands)
+risc0 = "build --release --target-dir target/risc0 --no-default-features --features risc0,testing"
+sp1 = "build --release --target-dir target/sp1 --no-default-features --features sp1,testing"
+mock = "build --release --target-dir target/mock --no-default-features --features mock,testing"
 
 # Test commands
 test-risc0 = "test --target-dir target/risc0 --no-default-features --features risc0,testing"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,28 @@
-# Cargo configuration for clvm-zk project
+# Cargo configuration for separate backend builds
 
-[build]
-# Enable some optimizations for faster test compilation
-incremental = true
+[alias]
+# Build commands
+build-risc0 = "build --target-dir target/risc0 --no-default-features --features risc0,testing"
+build-sp1 = "build --target-dir target/sp1 --no-default-features --features sp1,testing"
+build-mock = "build --target-dir target/mock --no-default-features --features mock,testing"
 
-[env]
-# Test configuration environment variables
-RUST_TEST_THREADS = "4"  # Limit concurrent tests to avoid resource contention
-ZK_TEST_TIMEOUT_SECONDS = "180"  # 3 minutes timeout for individual ZK proof tests
+# Release builds
+release-risc0 = "build --release --target-dir target/risc0 --no-default-features --features risc0,testing"
+release-sp1 = "build --release --target-dir target/sp1 --no-default-features --features sp1,testing"
 
-# For better test output
-RUST_BACKTRACE = "1"
+# Test commands
+test-risc0 = "test --target-dir target/risc0 --no-default-features --features risc0,testing"
+test-sp1 = "test --target-dir target/sp1 --no-default-features --features sp1,testing"
+test-mock = "test --target-dir target/mock --no-default-features --features mock,testing"
+
+# Run commands (use with -- <args>)
+run-risc0 = "run --target-dir target/risc0 --no-default-features --features risc0,testing"
+run-sp1 = "run --target-dir target/sp1 --no-default-features --features sp1,testing"
+
+# Check commands (fast compile check without building)
+check-risc0 = "check --target-dir target/risc0 --no-default-features --features risc0,testing"
+check-sp1 = "check --target-dir target/sp1 --no-default-features --features sp1,testing"
+
+# Clippy lints
+clippy-risc0 = "clippy --target-dir target/risc0 --no-default-features --features risc0,testing"
+clippy-sp1 = "clippy --target-dir target/sp1 --no-default-features --features sp1,testing"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,11 +14,14 @@ test-mock = "test --target-dir target/mock --no-default-features --features mock
 # Run commands (use with -- <args>)
 run-risc0 = "run --target-dir target/risc0 --no-default-features --features risc0,testing"
 run-sp1 = "run --target-dir target/sp1 --no-default-features --features sp1,testing"
+run-mock = "run --target-dir target/mock --no-default-features --features mock,testing"
 
 # Check commands (fast compile check without building)
 check-risc0 = "check --target-dir target/risc0 --no-default-features --features risc0,testing"
 check-sp1 = "check --target-dir target/sp1 --no-default-features --features sp1,testing"
+check-mock = "check --target-dir target/mock --no-default-features --features mock,testing"
 
 # Clippy lints
 clippy-risc0 = "clippy --target-dir target/risc0 --no-default-features --features risc0,testing"
 clippy-sp1 = "clippy --target-dir target/sp1 --no-default-features --features sp1,testing"
+clippy-mock = "clippy --target-dir target/mock --no-default-features --features mock,testing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,16 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            target/mock
+          key: ${{ runner.os }}-cargo-mock-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-mock-
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Run Clippy (lint)
-        run:  cargo clippy  --no-default-features --features mock,testing -- -D warnings
+        run: cargo clippy-mock -- -D warnings
 
       - name: Run tests
-        run: cargo test --no-default-features --features mock,testing -- --nocapture
+        run: cargo test-mock -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = ["sp1", "testing"]
 # when switching backends, use: cargo <cmd> --no-default-features --features <backend>,testing
 risc0 = ["dep:clvm-zk-risc0", "clvm-zk-core/risc0"]  # risc0 zkvm backend with precompiles
 sp1 = ["dep:clvm-zk-sp1", "clvm-zk-core/sp1"]        # sp1 zkvm backend (default, faster proving)
-mock = ["dep:clvm-zk-mock"]                           # mock backend for testing
+mock = ["dep:clvm-zk-mock", "clvm-zk-core/sha2-hasher"]  # mock backend for testing
 
 # testing utilities (enabled by default for tests)
 testing = ["clvm-zk-core/sha2-hasher"]
@@ -48,6 +48,7 @@ rand = "0.8"
 bip32 = "0.5"
 hmac = "0.12"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }  # For ECDSA signature verification
+rs_merkle = "1.5"  # For merkle tree proof generation on host
 
 # Backend implementations
 clvm-zk-risc0 = { path = "backends/risc0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ bip32 = "0.5"
 hmac = "0.12"
 k256 = { version = "0.13", features = ["ecdsa", "sha256"] }  # For ECDSA signature verification
 rs_merkle = "1.5"  # For merkle tree proof generation on host
+x25519-dalek = { version = "2.0", features = ["static_secrets"] }  # For ECDH key exchange in encrypted notes
+chacha20poly1305 = "0.10"  # For authenticated encryption of payment notes
 
 # Backend implementations
 clvm-zk-risc0 = { path = "backends/risc0", optional = true }

--- a/README.md
+++ b/README.md
@@ -2,34 +2,34 @@
 
 **Work in progress research project**
 
-Zero-knowledge proof system for running Chialisp (CLVM) programs privately. Take a chialisp program, prove it executed correctly, and verify that proof without revealing the inputs or program logic.
+Zero-knowledge proof system for running Chialisp (CLVM) programs privately. Generates proofs of correct execution without revealing inputs or program logic.
 
-General purpose zkvm approach - supports arbitrary chialisp programs instead of hardcoded circuits.
+Supports arbitrary Chialisp programs instead of hardcoded circuits.
 
 ## What it does
 
-- Run chialisp programs in zkvm (SP1 by default, RISC0 also supported)
+- Run Chialisp programs in zkVM (SP1 by default, RISC0 also supported)
 - Generate proofs that hide inputs and program logic
-- Verify proofs without seeing the private data
-- BLS and ECDSA signature verification support
+- Verify proofs without revealing private data
+- BLS and ECDSA signature verification
 
 
 ## Getting started
 
-### Quick start: simulator demo
+### Simulator demo
 
-fastest way to see veil in action:
+Run encrypted payment notes demo:
 
 ```bash
 # install dependencies
 ./install-deps.sh
 
-# run encrypted payment notes demo
-./sim_demo.sh         # risc0 backend (default)
-./sim_demo.sh sp1     # sp1 backend
+# run demo
+./sim_demo.sh         # RISC0 backend (default)
+./sim_demo.sh sp1     # SP1 backend
 ```
 
-see **[SIMULATOR.md](SIMULATOR.md)** for details.
+See **[SIMULATOR.md](SIMULATOR.md)** for details.
 
 ### Install dependencies
 
@@ -42,77 +42,47 @@ rustup target add riscv32im-unknown-none-elf
 curl -L https://risczero.com/install | bash && rzup
 ```
 
-### Backend-specific builds (recommended)
+### Build and test
 
-to prevent backends from overwriting each other's builds, use cargo aliases:
+Use backend-specific cargo aliases to avoid rebuilding when switching backends:
 
 ```bash
-# build commands
-cargo build-risc0        # debug build to target/risc0/
-cargo release-risc0      # release build to target/risc0/
-cargo build-sp1          # debug build to target/sp1/
-cargo release-sp1        # release build to target/sp1/
+# build (release)
+cargo risc0              # RISC0 backend to target/risc0/
+cargo sp1                # SP1 backend to target/sp1/
+cargo mock               # mock backend to target/mock/
 
-# run tests
-cargo test-risc0
-cargo test-sp1
+# test
+cargo test-risc0         # run all tests with RISC0
+cargo test-sp1           # run all tests with SP1
+cargo test-mock          # fast tests without zkVM
+
+# run
+cargo run-risc0 -- demo
+cargo run-sp1 -- prove --expression "(mod (a b) (+ a b))" --variables "5,3"
+
+# examples
+cargo run-risc0 --example alice_bob_lock
+cargo run-sp1 --example backend_benchmark
 
 # development
 cargo check-risc0        # fast compile check
 cargo clippy-risc0       # lints
 ```
 
-see **[CARGO_ALIASES.md](CARGO_ALIASES.md)** for complete documentation.
+Backend-specific builds prevent clobbering. Each backend uses ~1GB disk space. Aliases defined in `.cargo/config.toml`.
 
-**benefits:**
-- ✅ building sp1 won't delete risc0 binaries
-- ✅ switch between backends without rebuilding
-- ✅ parallel builds in different terminals
-- ⚠️  uses ~1GB per backend
-
-### Standard build (single backend at a time)
-
-```bash
-# default: sp1 backend (requires --release for proof generation)
-cargo build --release
-cargo test --release
-
-# risc0 backend
-cargo release-risc0
-cargo test-risc0 --release
-
-# mock backend (for testing without zkvm overhead)
-cargo test-mock
-```
-
-### Run examples
-
-```bash
-# run with cargo (use --release for actual proof generation)
-cargo run --release -- demo
-cargo run --release -- prove --expression "(mod (a b) (+ a b))" --variables "5,3"
-
-# or run binary directly (faster, no rebuild)
-./target/release/clvm-zk demo
-./target/release/clvm-zk prove --expression "(mod (a b) (+ a b))" --variables "5,3"
-./target/release/clvm-zk verify --proof-file proof.bin --template "(mod (a b) (+ a b))"
-
-# run code examples
-cargo run --release --example alice_bob_lock
-cargo run --release --example backend_benchmark
-```
-
-for simulator usage, see **[SIMULATOR.md](SIMULATOR.md)**.
+For simulator usage, see **[SIMULATOR.md](SIMULATOR.md)**.
 
 
 
-## Supported chialisp
+## Supported Chialisp
 
 **Arithmetic**: `+`, `-`, `*`, `divmod`, `modpow`
 **Comparison**: `=`, `>`, `<`
 **Control flow**: `i` (if-then-else), `if`
 **Lists**: `c` (cons), `f` (first), `r` (rest), `l` (length)
-**Functions**: helper functions with recursion support
+**Functions**: Helper functions with recursion support
 **Cryptography**: `sha256`, `ecdsa_verify`, `bls_verify`
 **Blockchain**: `create_coin`, `agg_sig_unsafe`, `reserve_fee`, etc
 **Modules**: `mod` wrapper syntax for named parameters
@@ -149,7 +119,7 @@ BLS signature verification (`bls_verify`) works on SP1 and RISC0 backends.
     0))
 ```
 
-See `tests/` for examples of supported operations.
+See `tests/` for examples.
 
 
 
@@ -217,36 +187,37 @@ clvm-zk/
 ### Core components
 
 #### `clvm_zk_core/` - Backend-agnostic compilation and execution
-Unconditionally no_std chialisp compiler and CLVM executor with dependency injection for zkvm-optimized crypto:
+no_std Chialisp compiler and CLVM executor with dependency injection for zkVM-optimized crypto:
 
 **Compilation:**
-- **`compile_chialisp_to_bytecode_with_table()`**: compiles chialisp source to CLVM bytecode with function table
-- **`compile_chialisp_template_hash()`**: generates deterministic program hashes for verification
-- **Compilation pipeline**: chialisp source → s-expressions → AST → CLVM bytecode → ClvmValue
+- **`compile_chialisp_to_bytecode_with_table()`**: Compiles Chialisp source to CLVM bytecode with function table
+- **`compile_chialisp_template_hash()`**: Generates deterministic program hashes for verification
+- **Compilation pipeline**: Chialisp source → s-expressions → AST → CLVM bytecode → ClvmValue
 
 **Execution:**
-- **`ClvmEvaluator`**: main evaluation struct with injected backend crypto
-  - `hasher: fn(&[u8]) -> [u8; 32]` - hash function (zkvm-optimized)
+- **`ClvmEvaluator`**: Main evaluation struct with injected backend crypto
+  - `hasher: fn(&[u8]) -> [u8; 32]` - Hash function (zkVM-optimized)
   - `bls_verifier: fn(&[u8], &[u8], &[u8]) -> Result<bool, &'static str>` - BLS signature verification
   - `ecdsa_verifier: fn(&[u8], &[u8], &[u8]) -> Result<bool, &'static str>` - ECDSA signature verification
-- **`evaluate_clvm_program()`**: executes bytecode with parameter substitution
-- **All CLVM opcodes**: arithmetic, comparison, list operations, conditionals, crypto, blockchain conditions
-  
-#### `backends/` - zkvm implementations
-Each backend provides host integration and guest program:
-- **risc0**: mature backend with optimized precompiles for BLS/ECDSA
-- **sp1**: default backend, potentially faster proving times
-- **mock**: no-zkvm testing backend for fast iteration
+- **`evaluate_clvm_program()`**: Executes bytecode with parameter substitution
+- **All CLVM opcodes**: Arithmetic, comparison, list operations, conditionals, crypto, blockchain conditions
 
-#### `examples/` - working code examples
+#### `backends/` - zkVM implementations
+Each backend provides host integration and guest program:
+- **RISC0**: Mature backend with optimized precompiles for BLS/ECDSA
+- **SP1**: Default backend, potentially faster proving times
+- **mock**: No-zkVM testing backend for fast iteration
+
+#### `examples/` - Working code examples
 - `alice_bob_lock.rs` - ECDSA signature verification with ZK proofs
-- `performance_profiling.rs` - performance benchmarking suite
-- `backend_benchmark.rs` - backend comparison tool
+- `performance_profiling.rs` - Performance benchmarking suite
+- `backend_benchmark.rs` - Backend comparison tool
+
 ## Development
 
 ### Basic usage
 
-`ClvmZkProver::prove(expression)` generates proofs. `ClvmZkProver::verify_proof()` verifies them. Expressions support named variables and `mod` wrapper syntax. Check `examples/` for working code.
+`ClvmZkProver::prove(expression)` generates proofs. `ClvmZkProver::verify_proof()` verifies them. Expressions support named variables and `mod` wrapper syntax. See `examples/` for working code.
 
 ### Examples
 
@@ -266,30 +237,83 @@ let result = ClvmZkProver::prove(chialisp_source, parameters)?;
 See `examples/` for complete working code including `alice_bob_lock.rs` for ECDSA signatures.
 
 
-**Flow**: Host sends chialisp source to guest → guest compiles and executes → returns proof with program hash.
+**Flow**: Host sends Chialisp source to guest → guest compiles and executes → returns proof with program hash.
 
 
+
+## Privacy protocols
+
+### Nullifier protocol
+
+Coins use serial commitment scheme to prevent double-spending while hiding which coin was spent:
+
+**Coin creation:**
+- Generate random `serial_number` and `serial_randomness`
+- `serial_commitment = hash("clvm_zk_serial_v1.0" || serial_number || serial_randomness)`
+- `coin_commitment = hash("clvm_zk_coin_v1.0" || amount || puzzle_hash || serial_commitment)`
+- Coin commitment added to merkle tree
+
+**Spending:**
+- Guest verifies: `puzzle_hash == program_hash` (proves running correct puzzle)
+- Guest verifies: `hash(serial_number || serial_randomness) == serial_commitment`
+- Guest verifies: `hash(amount || puzzle_hash || serial_commitment) == coin_commitment`
+- Guest verifies: Merkle membership of coin_commitment
+- Guest computes: `nullifier = hash(serial_number || program_hash)`
+- Proof reveals nullifier, hides which coin was spent
+
+**Security properties:**
+- Each coin has exactly one valid nullifier
+- Nullifier set tracks spent coins
+- Double-spending cryptographically impossible
+- Merkle proof shows coin exists without revealing which one
+- serial_randomness prevents linking nullifier to coin_commitment
+
+### Recovery protocol
+
+Encrypted payment notes enable offline receiving and backup recovery:
+
+**Sending:**
+- Alice generates coin with random serial_number and serial_randomness
+- Alice encrypts `(serial_number, serial_randomness)` to Bob's x25519 viewing key
+- Alice publishes encrypted note on-chain alongside transaction
+
+**Receiving:**
+- Bob scans blockchain with x25519 decryption key
+- Bob decrypts notes to discover coins sent to him
+- Bob stores coin secrets locally
+
+**Recovery:**
+- Bob re-scans blockchain with viewing key
+- Recovers all coins from encrypted notes
+- Works offline - no interaction with sender needed
+
+**Privacy:**
+- Alice cannot track Bob's spending after sending
+- Encrypted notes unlinkable to coin commitments
+- Viewing key enables read-only access
+
+See **[ENCRYPTED_NOTES.md](ENCRYPTED_NOTES.md)** and **[nullifier.md](nullifier.md)** for detailed specifications.
 
 ## Blockchain simulator
 
-local privacy-preserving blockchain simulator with encrypted payment notes, hd wallets, persistent state, and real zk proofs.
+Local privacy-preserving blockchain simulator with encrypted payment notes, HD wallets, persistent state, and real ZK proofs.
 
 ```bash
 # run the full demo
-./sim_demo.sh         # risc0 backend (default)
-./sim_demo.sh sp1     # sp1 backend
+./sim_demo.sh         # RISC0 backend (default)
+./sim_demo.sh sp1     # SP1 backend
 ```
 
-see **[SIMULATOR.md](SIMULATOR.md)** for complete documentation and usage examples.
+See **[SIMULATOR.md](SIMULATOR.md)** for complete documentation and usage examples.
 
 
-## Adding new zkvm backends
+## Adding new zkVM backends
 
-To add a new zkvm backend:
+To add a new zkVM backend:
 
 1. Create `backends/your_zkvm/src/lib.rs` implementing the backend
 2. Create guest program using `clvm_zk_core` (no_std compatible)
-3. Inject zkvm-optimized crypto functions into `ClvmEvaluator`
+3. Inject zkVM-optimized crypto functions into `ClvmEvaluator`
 4. Add feature flag to workspace `Cargo.toml`
 5. Implement `ZKCLVMBackend` trait in `src/backends.rs`
 
@@ -297,12 +321,12 @@ See `backends/risc0/` or `backends/sp1/` as reference implementations.
 
 ## Contributing
 
-Areas where help would be useful:
+Contributions welcome in these areas:
 - Performance optimizations
-- More chialisp operations
-- Better error messages
-- Documentation improvements
-- More test cases
-- New zkvm backends
+- Chialisp operations
+- Error messages
+- Documentation
+- Test cases
+- zkVM backends
 
-Check the test suite in `tests/` to understand how everything works.
+See test suite in `tests/` for implementation patterns.

--- a/README.md
+++ b/README.md
@@ -16,59 +16,93 @@ General purpose zkvm approach - supports arbitrary chialisp programs instead of 
 
 ## Getting started
 
+### Quick start: simulator demo
+
+fastest way to see veil in action:
+
+```bash
+# install dependencies
+./install-deps.sh
+
+# run encrypted payment notes demo
+./sim_demo.sh         # risc0 backend (default)
+./sim_demo.sh sp1     # sp1 backend
+```
+
+see **[SIMULATOR.md](SIMULATOR.md)** for details.
+
 ### Install dependencies
 
 ```bash
-# Install dependencies
+# install dependencies
 ./install-deps.sh
 
-# Manual
+# manual installation
 rustup target add riscv32im-unknown-none-elf
 curl -L https://risczero.com/install | bash && rzup
 ```
 
-### Choose backend
+### Backend-specific builds (recommended)
+
+to prevent backends from overwriting each other's builds, use cargo aliases:
 
 ```bash
-# Default: SP1 backend (requires --release for proof generation)
-cargo build --release
-cargo test --release
-cargo test --release --test <test file name>
+# build commands
+cargo build-risc0        # debug build to target/risc0/
+cargo release-risc0      # release build to target/risc0/
+cargo build-sp1          # debug build to target/sp1/
+cargo release-sp1        # release build to target/sp1/
 
-# Use RISC0 backend (requires --release for proof generation)
-cargo build --release --no-default-features --features risc0,testing
-cargo test --release --no-default-features --features "risc0,testing"
+# run tests
+cargo test-risc0
+cargo test-sp1
 
-# Use mock backend (for testing without zkvm overhead, no --release needed)
-cargo test --no-default-features --features "mock,testing"
+# development
+cargo check-risc0        # fast compile check
+cargo clippy-risc0       # lints
 ```
 
-### Build and run
+see **[CARGO_ALIASES.md](CARGO_ALIASES.md)** for complete documentation.
+
+**benefits:**
+- ✅ building sp1 won't delete risc0 binaries
+- ✅ switch between backends without rebuilding
+- ✅ parallel builds in different terminals
+- ⚠️  uses ~1GB per backend
+
+### Standard build (single backend at a time)
 
 ```bash
-# Build the binary
+# default: sp1 backend (requires --release for proof generation)
 cargo build --release
+cargo test --release
 
-# Run with cargo (use --release for actual proof generation)
+# risc0 backend
+cargo release-risc0
+cargo test-risc0 --release
+
+# mock backend (for testing without zkvm overhead)
+cargo test-mock
+```
+
+### Run examples
+
+```bash
+# run with cargo (use --release for actual proof generation)
 cargo run --release -- demo
 cargo run --release -- prove --expression "(mod (a b) (+ a b))" --variables "5,3"
 
-# Or run the binary directly (faster, no rebuild)
+# or run binary directly (faster, no rebuild)
 ./target/release/clvm-zk demo
 ./target/release/clvm-zk prove --expression "(mod (a b) (+ a b))" --variables "5,3"
 ./target/release/clvm-zk verify --proof-file proof.bin --template "(mod (a b) (+ a b))"
 
-# Interactive demo
-./target/release/clvm-zk demo
-
-# Start simulator
-./target/release/clvm-zk sim init
-./target/release/clvm-zk sim wallet alice create
-./target/release/clvm-zk sim faucet alice --amount 1000 --count 5
-
-# Run examples
-cargo run --release --example <name>
+# run code examples
+cargo run --release --example alice_bob_lock
+cargo run --release --example backend_benchmark
 ```
+
+for simulator usage, see **[SIMULATOR.md](SIMULATOR.md)**.
 
 
 
@@ -238,9 +272,15 @@ See `examples/` for complete working code including `alice_bob_lock.rs` for ECDS
 
 ## Blockchain simulator
 
-Privacy-preserving blockchain simulator for local testing. Create wallets, send private transactions, and generate real ZK proofs without setting up a real blockchain.
+local privacy-preserving blockchain simulator with encrypted payment notes, hd wallets, persistent state, and real zk proofs.
 
-See **[SIMULATOR.md](SIMULATOR.md)** for detailed documentation.
+```bash
+# run the full demo
+./sim_demo.sh         # risc0 backend (default)
+./sim_demo.sh sp1     # sp1 backend
+```
+
+see **[SIMULATOR.md](SIMULATOR.md)** for complete documentation and usage examples.
 
 
 ## Adding new zkvm backends

--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -59,35 +59,29 @@ nullifier = hash(serial_number || program_hash)
 
 ## Quick start
 
-### automated demo script
+### Demo script
 
-fastest way to see the full simulator in action:
+Run the full encrypted payment notes demo:
 
 ```bash
-# run encrypted payment notes demo with risc0 backend (default)
-./sim_demo.sh
-
-# or use sp1 backend
-./sim_demo.sh sp1
+./sim_demo.sh         # RISC0 backend (default)
+./sim_demo.sh sp1     # SP1 backend
 ```
 
-the script:
-- auto-builds the backend if needed (builds to `target/risc0/` or `target/sp1/`)
-- resets simulator state
-- creates alice and bob wallets
-- funds alice with coins
-- alice sends to bob (bob offline)
-- bob scans and discovers payments
-- bob sends back to alice
-- shows timing metrics for all operations
-- displays final balances and proof count
+**What it does:**
+1. Builds backend if needed (`target/risc0/` or `target/sp1/`)
+2. Resets simulator state
+3. Creates alice and bob wallets with HD keys
+4. Funds alice from faucet
+5. Alice sends to bob (bob offline, doesn't receive yet)
+6. Bob scans blockchain and discovers payments via encrypted notes
+7. Bob sends back to alice
+8. Shows timing and final balances
 
-expected timing:
-- risc0: ~11s per send transaction
-- sp1: ~15s per send transaction
-- scan operations: instant (no zkvm execution)
 
-output saved to `simulator_data/state.json` with all zk proofs (~245kb each).
+- Scan operations: instant (decryption only, no zkVM)
+
+**Output:** Persistent state in `simulator_data/state.json` with all ZK proofs.
 
 ### manual commands
 
@@ -218,7 +212,7 @@ cargo run-mock -- sim init
 **Always use `--release` for SP1 and RISC0 backends** - they require release mode for proof generation.
 Use mock backend for fast testing without real proofs: `cargo run-mock -- sim init`
 Reset corrupted state with `cargo run-sp1 --release -- sim init --reset`
-Switch backends using cargo aliases: `cargo run-risc0`, `cargo run-sp1`, or `cargo run-mock` (see [CARGO_ALIASES.md](CARGO_ALIASES.md))
+Switch backends using cargo aliases: `cargo run-risc0`, `cargo run-sp1`
 
 ## Use cases
 

--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -128,6 +128,20 @@ cargo run --release -- sim wallet alice unspent       # Show unspent coins
 cargo run --release -- sim wallet alice balance       # Show balance only
 ```
 
+## encrypted payment notes
+
+- alice sends to bob → creates encrypted note (bob doesn't receive coin yet)
+- bob runs `sim scan bob` → decrypts notes, discovers payments
+- uses x25519 ecdh + chacha20-poly1305 authenticated encryption
+- supports memos (e.g., "payment from alice")
+
+see [ENCRYPTED_NOTES.md](ENCRYPTED_NOTES.md) for full documentation.
+
+**quick test:**
+```bash
+./TEST_ENCRYPTED_NOTES.sh
+```
+
 ## Features
 
 - Real ZK proof generation using RISC0/SP1 backends

--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -41,23 +41,55 @@ so you can't replay proofs across different puzzle types - the program hash BIND
 
 ## Quick start
 
+### automated demo script
+
+fastest way to see the full simulator in action:
+
+```bash
+# run encrypted payment notes demo with risc0 backend (default)
+./sim_demo.sh
+
+# or use sp1 backend
+./sim_demo.sh sp1
+```
+
+the script:
+- auto-builds the backend if needed (builds to `target/risc0/` or `target/sp1/`)
+- resets simulator state
+- creates alice and bob wallets
+- funds alice with coins
+- alice sends to bob (bob offline)
+- bob scans and discovers payments
+- bob sends back to alice
+- shows timing metrics for all operations
+- displays final balances and proof count
+
+expected timing:
+- risc0: ~11s per send transaction
+- sp1: ~15s per send transaction
+- scan operations: instant (no zkvm execution)
+
+output saved to `simulator_data/state.json` with all zk proofs (~245kb each).
+
+### manual commands
+
 ```bash
 # Initialize the simulator (use --release for actual proof generation)
-cargo run --release -- sim init
+cargo run-sp1 --release -- sim init
 
 # Create wallet
-cargo run --release -- sim wallet alice create
+cargo run-sp1 --release -- sim wallet alice create
 
 # Fund it from the faucet
-cargo run --release -- sim faucet alice --amount 5000
+cargo run-sp1 --release -- sim faucet alice --amount 5000
 
 # Check your balance
-cargo run --release -- sim wallet alice show
+cargo run-sp1 --release -- sim wallet alice show
 ```
 
 Run tests with:
 ```bash
-cargo test --release --test simulator_tests
+cargo test-sp1 --release --test simulator_tests
 ```
 
 ## How it works
@@ -77,33 +109,33 @@ Everything gets saved to `./simulator_data/state.json`:
 ### Basic setup
 ```bash
 # Initialize simulator (use --release for actual proof generation)
-cargo run --release -- sim init
+cargo run-sp1 --release -- sim init
 
 # Create wallets
-cargo run --release -- sim wallet alice create
-cargo run --release -- sim wallet bob create
+cargo run-sp1 --release -- sim wallet alice create
+cargo run-sp1 --release -- sim wallet bob create
 
 # Fund wallet from faucet
-cargo run --release -- sim faucet alice --amount 5000 --count 3
+cargo run-sp1 --release -- sim faucet alice --amount 5000 --count 3
 
 # Check wallet status
-cargo run --release -- sim wallet alice show
-cargo run --release -- sim status
+cargo run-sp1 --release -- sim wallet alice show
+cargo run-sp1 --release -- sim status
 ```
 
 ### Private transactions
 ```bash
 # Generate password puzzle program
-cargo run --release -- hash-password mysecret
+cargo run-sp1 --release -- hash-password mysecret
 # Output: (= (sha256 password) 0x652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0)
 
 # Alice locks coins with password
-cargo run --release -- sim spend-to-puzzle alice 3000 \
+cargo run-sp1 --release -- sim spend-to-puzzle alice 3000 \
   "(= (sha256 password) 0x652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0)" \
   --coins "0"
 
 # Bob unlocks with password
-cargo run --release -- sim spend-to-wallet \
+cargo run-sp1 --release -- sim spend-to-wallet \
   "(= (sha256 password) 0x652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0)" \
   bob 3000 --params "mysecret"
 ```
@@ -111,21 +143,21 @@ cargo run --release -- sim spend-to-wallet \
 ### More examples
 ```bash
 # Send between wallets
-cargo run --release -- sim send alice bob 2000 --coins "0,1"
+cargo run-sp1 --release -- sim send alice bob 2000 --coins "0,1"
 
 # Custom puzzle programs
-cargo run --release -- sim spend-to-puzzle alice 1000 "(> minimum_amount 100)" --coins "auto"
-cargo run --release -- sim spend-to-wallet "(> minimum_amount 100)" bob 1000 --params "150"
+cargo run-sp1 --release -- sim spend-to-puzzle alice 1000 "(> minimum_amount 100)" --coins "auto"
+cargo run-sp1 --release -- sim spend-to-wallet "(> minimum_amount 100)" bob 1000 --params "150"
 
 # Using mod wrapper syntax for named parameters
-cargo run --release -- sim spend-to-puzzle alice 1000 "(mod (threshold) (> threshold 100))" --coins "auto"
-cargo run --release -- sim spend-to-wallet "(mod (threshold) (> threshold 100))" bob 1000 --params "150"
+cargo run-sp1 --release -- sim spend-to-puzzle alice 1000 "(mod (threshold) (> threshold 100))" --coins "auto"
+cargo run-sp1 --release -- sim spend-to-wallet "(mod (threshold) (> threshold 100))" bob 1000 --params "150"
 
 # Wallet management
-cargo run --release -- sim wallets                    # List all wallets
-cargo run --release -- sim wallet alice coins         # Show all coins
-cargo run --release -- sim wallet alice unspent       # Show unspent coins
-cargo run --release -- sim wallet alice balance       # Show balance only
+cargo run-sp1 --release -- sim wallets                    # List all wallets
+cargo run-sp1 --release -- sim wallet alice coins         # Show all coins
+cargo run-sp1 --release -- sim wallet alice unspent       # Show unspent coins
+cargo run-sp1 --release -- sim wallet alice balance       # Show balance only
 ```
 
 ## encrypted payment notes
@@ -154,21 +186,21 @@ see [ENCRYPTED_NOTES.md](ENCRYPTED_NOTES.md) for full documentation.
 ### Choose zk backend
 ```bash
 # Default: SP1 backend (requires --release)
-cargo run --release -- sim init
+cargo run-sp1 --release -- sim init
 
 # Use RISC0 backend (requires --release)
-cargo run --release --no-default-features --features risc0,testing -- sim init
+cargo run-risc0 --release -- sim init
 
 # Use mock backend for fast testing (no real proofs, no --release needed)
-cargo run --no-default-features --features mock,testing -- sim init
+cargo run-mock -- sim init
 ```
 
 ## Troubleshooting
 
 **Always use `--release` for SP1 and RISC0 backends** - they require release mode for proof generation.
-Use mock backend for fast testing without real proofs: `cargo run --no-default-features --features mock,testing -- sim init`
-Reset corrupted state with `cargo run --release -- sim init --reset`
-Switch backends with feature flags: `--no-default-features --features risc0,testing` or `--features mock,testing`
+Use mock backend for fast testing without real proofs: `cargo run-mock -- sim init`
+Reset corrupted state with `cargo run-sp1 --release -- sim init --reset`
+Switch backends using cargo aliases: `cargo run-risc0`, `cargo run-sp1`, or `cargo run-mock` (see [CARGO_ALIASES.md](CARGO_ALIASES.md))
 
 ## Use cases
 

--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -35,20 +35,24 @@ when creating a coin:
 serial_number = random(32 bytes)
 serial_randomness = random(32 bytes)
 serial_commitment = hash("clvm_zk_serial_v1.0" || serial_number || serial_randomness)
-coin_commitment = hash(puzzle_hash || amount || serial_commitment)
+coin_commitment = hash("clvm_zk_coin_v1.0" || puzzle_hash || serial_commitment)
 ```
 
 when spending a coin:
 ```
-nullifier = serial_number  // revealed in proof
+// Guest verifies:
 verify: hash(serial_number || serial_randomness) == serial_commitment
 verify: coin_commitment exists in merkle tree
+
+// Guest computes and reveals:
+nullifier = hash(serial_number || program_hash)
 ```
 
 **security properties:**
-- each coin has exactly one valid nullifier (the serial_number)
-- revealing serial_number doesn't break privacy (unlinkable to coin_commitment)
-- double-spend impossible: same serial_number can only be used once
+- each coin has exactly one valid nullifier for its (serial_number, program_hash) pair
+- nullifier = hash(serial_number || program_hash) - uniquely identifies spent coin
+- serial_randomness excluded from nullifier to prevent linkability with coin_commitment
+- double-spend impossible: same nullifier can only be revealed once
 - merkle membership proves coin exists without revealing which coin
 
 **critical:** losing serial_number or serial_randomness = permanent coin loss. see [ENCRYPTED_NOTES.md](ENCRYPTED_NOTES.md) for backup procedures.

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -109,13 +109,14 @@ impl MockBackend {
         inputs: clvm_zk_core::Input,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         let (instance_bytecode, program_hash, function_table) =
-            compile_chialisp_to_bytecode_with_table(hash_data, &inputs.chialisp_source, &inputs.program_parameters)
-                .map_err(|e| {
-                    ClvmZkError::ProofGenerationFailed(format!(
-                        "chialisp compilation failed: {:?}",
-                        e
-                    ))
-                })?;
+            compile_chialisp_to_bytecode_with_table(
+                hash_data,
+                &inputs.chialisp_source,
+                &inputs.program_parameters,
+            )
+            .map_err(|e| {
+                ClvmZkError::ProofGenerationFailed(format!("chialisp compilation failed: {:?}", e))
+            })?;
 
         let mut evaluator = ClvmEvaluator::new(hash_data, default_bls_verifier, ecdsa_verifier);
         evaluator.function_table = function_table;

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -106,7 +106,7 @@ impl MockBackend {
 
     pub fn prove_with_input(
         &self,
-        inputs: clvm_zk_core::Input,
+        inputs: clvm_zk_core::InputWithSerial,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         let (instance_bytecode, program_hash, function_table) =
             compile_chialisp_to_bytecode_with_table(
@@ -132,13 +132,80 @@ impl MockBackend {
             cost: 0,
         };
 
-        // extract nullifier from input
-        // serial_number is the nullifier
-        let nullifier = inputs.serial_number;
+        // Serial commitment protocol for spending
+        let serial_randomness = inputs.serial_randomness;
+        let serial_number = inputs.serial_number;
+        let puzzle_hash = inputs.program_hash;
+        // 1. Verify program_hash matches puzzle_hash
+        if program_hash != puzzle_hash {
+            return Err(ClvmZkError::ProofGenerationFailed(
+                "program_hash mismatch: cannot spend coin with different puzzle".to_string(),
+            ));
+        }
+
+        // 2. Verify serial commitment
+        let domain = b"clvm_zk_serial_v1.0";
+        let mut commitment_data = Vec::with_capacity(19 + 64);
+        commitment_data.extend_from_slice(domain);
+        commitment_data.extend_from_slice(&serial_number);
+        commitment_data.extend_from_slice(&serial_randomness);
+        let computed_serial_commitment = hash_data(&commitment_data);
+
+        let serial_commitment_expected = inputs.serial_commitment;
+        if computed_serial_commitment != serial_commitment_expected {
+            return Err(ClvmZkError::ProofGenerationFailed(
+                "serial commitment verification failed".to_string(),
+            ));
+        }
+
+        // 3. Reconstruct and verify coin_commitment = hash(domain || puzzle_hash || serial_commitment)
+        let coin_domain = b"clvm_zk_coin_v1.0";
+        let mut coin_data = Vec::with_capacity(17 + 64);
+        coin_data.extend_from_slice(coin_domain);
+        coin_data.extend_from_slice(&puzzle_hash);
+        coin_data.extend_from_slice(&computed_serial_commitment);
+        let computed_coin_commitment = hash_data(&coin_data);
+        let coin_commitment_provided = inputs.coin_commitment;
+        if computed_coin_commitment != coin_commitment_provided {
+            return Err(ClvmZkError::ProofGenerationFailed(
+                "coin commitment verification failed".to_string(),
+            ));
+        }
+        // 4. Verify merkle membership
+        let merkle_path = inputs.merkle_path;
+        let expected_root = inputs.merkle_root;
+        let leaf_index = inputs.leaf_index;
+        let mut current_hash = computed_coin_commitment;
+        let mut current_index = leaf_index;
+        for sibling in merkle_path.iter() {
+            let mut combined = [0u8; 64];
+            if current_index % 2 == 0 {
+                combined[..32].copy_from_slice(&current_hash);
+                combined[32..].copy_from_slice(sibling);
+            } else {
+                combined[..32].copy_from_slice(sibling);
+                combined[32..].copy_from_slice(&current_hash);
+            }
+            current_hash = hash_data(&combined);
+            current_index /= 2;
+        }
+
+        let computed_root = current_hash;
+        if computed_root != expected_root {
+            return Err(ClvmZkError::ProofGenerationFailed(
+                "merkle root mismatch: coin not in current tree state".to_string(),
+            ));
+        }
+
+        // 5. Compute nullifier = hash(serial_number || program_hash)
+        let mut nullifier_data = Vec::with_capacity(64);
+        nullifier_data.extend_from_slice(&serial_number);
+        nullifier_data.extend_from_slice(&program_hash);
+        let nullifier = hash_data(&nullifier_data);
 
         let proof_output = ProofOutput {
             program_hash,
-            nullifier,
+            nullifier: Some(nullifier),
             clvm_res: clvm_output.clone(),
         };
 

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -133,8 +133,8 @@ impl MockBackend {
         };
 
         // extract nullifier from input
-        // serial_number is passed via spend_secret field
-        let nullifier = inputs.spend_secret;
+        // serial_number is the nullifier
+        let nullifier = inputs.serial_number;
 
         let proof_output = ProofOutput {
             program_hash,

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -106,7 +106,7 @@ impl MockBackend {
 
     pub fn prove_with_input(
         &self,
-        inputs: clvm_zk_core::InputWithSerial,
+        inputs: clvm_zk_core::Input,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         let (instance_bytecode, program_hash, function_table) =
             compile_chialisp_to_bytecode_with_table(
@@ -132,80 +132,85 @@ impl MockBackend {
             cost: 0,
         };
 
-        // Serial commitment protocol for spending
-        let serial_randomness = inputs.serial_randomness;
-        let serial_number = inputs.serial_number;
-        let puzzle_hash = inputs.program_hash;
-        // 1. Verify program_hash matches puzzle_hash
-        if program_hash != puzzle_hash {
-            return Err(ClvmZkError::ProofGenerationFailed(
-                "program_hash mismatch: cannot spend coin with different puzzle".to_string(),
-            ));
-        }
+        let nullifier = match inputs.serial_commitment_data {
+            Some(commitment_data) => {
+                let serial_randomness = commitment_data.serial_randomness;
+                let serial_number = commitment_data.serial_number;
+                let puzzle_hash = commitment_data.program_hash;
 
-        // 2. Verify serial commitment
-        let domain = b"clvm_zk_serial_v1.0";
-        let mut commitment_data = Vec::with_capacity(19 + 64);
-        commitment_data.extend_from_slice(domain);
-        commitment_data.extend_from_slice(&serial_number);
-        commitment_data.extend_from_slice(&serial_randomness);
-        let computed_serial_commitment = hash_data(&commitment_data);
+                if program_hash != puzzle_hash {
+                    return Err(ClvmZkError::ProofGenerationFailed(
+                        "program_hash mismatch: cannot spend coin with different puzzle"
+                            .to_string(),
+                    ));
+                }
 
-        let serial_commitment_expected = inputs.serial_commitment;
-        if computed_serial_commitment != serial_commitment_expected {
-            return Err(ClvmZkError::ProofGenerationFailed(
-                "serial commitment verification failed".to_string(),
-            ));
-        }
+                let domain = b"clvm_zk_serial_v1.0";
+                let mut serial_commit_data = Vec::with_capacity(19 + 64);
+                serial_commit_data.extend_from_slice(domain);
+                serial_commit_data.extend_from_slice(&serial_number);
+                serial_commit_data.extend_from_slice(&serial_randomness);
+                let computed_serial_commitment = hash_data(&serial_commit_data);
 
-        // 3. Reconstruct and verify coin_commitment = hash(domain || puzzle_hash || serial_commitment)
-        let coin_domain = b"clvm_zk_coin_v1.0";
-        let mut coin_data = Vec::with_capacity(17 + 64);
-        coin_data.extend_from_slice(coin_domain);
-        coin_data.extend_from_slice(&puzzle_hash);
-        coin_data.extend_from_slice(&computed_serial_commitment);
-        let computed_coin_commitment = hash_data(&coin_data);
-        let coin_commitment_provided = inputs.coin_commitment;
-        if computed_coin_commitment != coin_commitment_provided {
-            return Err(ClvmZkError::ProofGenerationFailed(
-                "coin commitment verification failed".to_string(),
-            ));
-        }
-        // 4. Verify merkle membership
-        let merkle_path = inputs.merkle_path;
-        let expected_root = inputs.merkle_root;
-        let leaf_index = inputs.leaf_index;
-        let mut current_hash = computed_coin_commitment;
-        let mut current_index = leaf_index;
-        for sibling in merkle_path.iter() {
-            let mut combined = [0u8; 64];
-            if current_index % 2 == 0 {
-                combined[..32].copy_from_slice(&current_hash);
-                combined[32..].copy_from_slice(sibling);
-            } else {
-                combined[..32].copy_from_slice(sibling);
-                combined[32..].copy_from_slice(&current_hash);
+                let serial_commitment_expected = commitment_data.serial_commitment;
+                if computed_serial_commitment != serial_commitment_expected {
+                    return Err(ClvmZkError::ProofGenerationFailed(
+                        "serial commitment verification failed".to_string(),
+                    ));
+                }
+
+                let coin_domain = b"clvm_zk_coin_v1.0";
+                let amount = commitment_data.amount;
+                let mut coin_data = [0u8; 17 + 8 + 32 + 32];
+                coin_data[..17].copy_from_slice(coin_domain);
+                coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+                coin_data[25..57].copy_from_slice(&program_hash);
+                coin_data[57..89].copy_from_slice(&computed_serial_commitment);
+                let computed_coin_commitment = hash_data(&coin_data);
+
+                let coin_commitment_provided = commitment_data.coin_commitment;
+                if computed_coin_commitment != coin_commitment_provided {
+                    return Err(ClvmZkError::ProofGenerationFailed(
+                        "coin commitment verification failed".to_string(),
+                    ));
+                }
+
+                let merkle_path = commitment_data.merkle_path;
+                let expected_root = commitment_data.merkle_root;
+                let leaf_index = commitment_data.leaf_index;
+                let mut current_hash = computed_coin_commitment;
+                let mut current_index = leaf_index;
+                for sibling in merkle_path.iter() {
+                    let mut combined = [0u8; 64];
+                    if current_index % 2 == 0 {
+                        combined[..32].copy_from_slice(&current_hash);
+                        combined[32..].copy_from_slice(sibling);
+                    } else {
+                        combined[..32].copy_from_slice(sibling);
+                        combined[32..].copy_from_slice(&current_hash);
+                    }
+                    current_hash = hash_data(&combined);
+                    current_index /= 2;
+                }
+
+                let computed_root = current_hash;
+                if computed_root != expected_root {
+                    return Err(ClvmZkError::ProofGenerationFailed(
+                        "merkle root mismatch: coin not in current tree state".to_string(),
+                    ));
+                }
+
+                let mut nullifier_data = Vec::with_capacity(64);
+                nullifier_data.extend_from_slice(&serial_number);
+                nullifier_data.extend_from_slice(&program_hash);
+                Some(hash_data(&nullifier_data))
             }
-            current_hash = hash_data(&combined);
-            current_index /= 2;
-        }
-
-        let computed_root = current_hash;
-        if computed_root != expected_root {
-            return Err(ClvmZkError::ProofGenerationFailed(
-                "merkle root mismatch: coin not in current tree state".to_string(),
-            ));
-        }
-
-        // 5. Compute nullifier = hash(serial_number || program_hash)
-        let mut nullifier_data = Vec::with_capacity(64);
-        nullifier_data.extend_from_slice(&serial_number);
-        nullifier_data.extend_from_slice(&program_hash);
-        let nullifier = hash_data(&nullifier_data);
+            None => None,
+        };
 
         let proof_output = ProofOutput {
             program_hash,
-            nullifier: Some(nullifier),
+            nullifier,
             clvm_res: clvm_output.clone(),
         };
 

--- a/backends/risc0/guest/src/main.rs
+++ b/backends/risc0/guest/src/main.rs
@@ -104,7 +104,9 @@ fn main() {
         let serial_commitment_expected = private_inputs
             .serial_commitment
             .expect("serial_commitment required with serial_randomness");
-        let serial_number = private_inputs.spend_secret.expect("serial_number required with serial_randomness");
+        let serial_number = private_inputs
+            .spend_secret
+            .expect("serial_number required with serial_randomness");
 
         let domain = b"clvm_zk_serial_v1.0";
         let mut commitment_data = [0u8; 83];

--- a/backends/risc0/guest/src/main.rs
+++ b/backends/risc0/guest/src/main.rs
@@ -4,7 +4,8 @@ use risc0_zkvm::guest::env;
 use risc0_zkvm::sha::{Impl, Sha256 as RiscSha256};
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, InputWithSerial,
+    ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -83,7 +84,7 @@ fn risc0_verify_ecdsa(
 fn main() {
     let start_cycles = env::cycle_count();
 
-    let private_inputs: Input = env::read();
+    let private_inputs: InputWithSerial = env::read();
     let (instance_bytecode, program_hash, function_table) =
         compile_chialisp_to_bytecode_with_table(
             risc0_hasher,
@@ -94,88 +95,86 @@ fn main() {
 
     let mut evaluator = ClvmEvaluator::new(risc0_hasher, risc0_verify_bls, risc0_verify_ecdsa);
     evaluator.function_table = function_table;
-    let (output_bytes, conditions) = evaluator
+    let (output_bytes, _conditions) = evaluator
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
-
     // Serial commitment protocol for spending
-    let nullifier = if let Some(serial_randomness) = private_inputs.serial_randomness {
-        // CRITICAL: Verify the program being executed matches the coin's puzzle_hash
-        let expected_puzzle_hash = private_inputs
-            .puzzle_hash
-            .expect("puzzle_hash required with serial_randomness");
-        assert_eq!(
-            program_hash, expected_puzzle_hash,
-            "program_hash mismatch: cannot spend coin with different puzzle"
-        );
-        // Verify serial commitment and merkle membership
-        let serial_commitment_expected = private_inputs
-            .serial_commitment
-            .expect("serial_commitment required with serial_randomness");
-        let serial_number = private_inputs
-            .serial_number
-            .expect("serial_number required with serial_randomness");
+    let expected_program_hash = private_inputs.program_hash;
+    assert_eq!(
+        program_hash, expected_program_hash,
+        "program_hash mismatch: cannot spend coin with different program"
+    );
+    let serial_number = private_inputs.serial_number;
+    let serial_randomness = private_inputs.serial_randomness;
+    let domain = b"clvm_zk_serial_v1.0";
+    let mut commitment_data = [0u8; 83];
+    commitment_data[..19].copy_from_slice(domain);
+    commitment_data[19..51].copy_from_slice(&serial_number);
+    commitment_data[51..83].copy_from_slice(&serial_randomness);
+    let computed_serial_commitment = risc0_hasher(&commitment_data);
 
-        let domain = b"clvm_zk_serial_v1.0";
-        let mut commitment_data = [0u8; 83];
-        commitment_data[..19].copy_from_slice(domain);
-        commitment_data[19..51].copy_from_slice(&serial_number);
-        commitment_data[51..83].copy_from_slice(&serial_randomness);
-        let computed_serial_commitment = risc0_hasher(&commitment_data);
+    let serial_commitment_expected = private_inputs.serial_commitment;
+    assert_eq!(
+        computed_serial_commitment, serial_commitment_expected,
+        "serial commitment verification failed"
+    );
+    let amount = private_inputs.amount;
+    // 3. Reconstruct and verify coin_commitment = hash(domain || program_hash || serial_commitment)
+    let coin_domain = b"clvm_zk_coin_v1.0";
+    let mut coin_data = [0u8; 17 + 32 + 8 + 32];
+    coin_data[..17].copy_from_slice(coin_domain);
+    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+    coin_data[25..57].copy_from_slice(&program_hash);
+    coin_data[57..89].copy_from_slice(&computed_serial_commitment);
+    let computed_coin_commitment = risc0_hasher(&coin_data);
+    let coin_commitment_provided = private_inputs.coin_commitment;
+    assert_eq!(
+        computed_coin_commitment, coin_commitment_provided,
+        "coin commitment verification failed"
+    );
 
-        assert_eq!(
-            computed_serial_commitment, serial_commitment_expected,
-            "serial commitment verification failed"
-        );
+    // 4. Verify merkle membership
+    let merkle_path = private_inputs.merkle_path;
+    let expected_root = private_inputs.merkle_root;
+    let leaf_index = private_inputs.leaf_index;
 
-        let coin_commitment = private_inputs
-            .coin_commitment
-            .expect("coin_commitment required");
-        let merkle_path = private_inputs.merkle_path.expect("merkle_path required");
-        let expected_root = private_inputs.merkle_root.expect("merkle_root required");
-        let leaf_index = private_inputs.leaf_index.expect("leaf_index required");
-
-        let mut current_hash = coin_commitment;
-        let mut current_index = leaf_index;
-        for sibling in merkle_path.iter() {
-            let mut combined = [0u8; 64];
-            // position-based hashing: if index is even (left child), sibling goes right
-            if current_index % 2 == 0 {
-                combined[..32].copy_from_slice(&current_hash);
-                combined[32..].copy_from_slice(sibling);
-            } else {
-                combined[..32].copy_from_slice(sibling);
-                combined[32..].copy_from_slice(&current_hash);
-            }
-            current_hash = risc0_hasher(&combined);
-            current_index /= 2; // move to parent level
+    let mut current_hash = computed_coin_commitment;
+    let mut current_index = leaf_index;
+    for sibling in merkle_path.iter() {
+        let mut combined = [0u8; 64];
+        // position-based hashing: if index is even (left child), sibling goes right
+        if current_index % 2 == 0 {
+            combined[..32].copy_from_slice(&current_hash);
+            combined[32..].copy_from_slice(sibling);
+        } else {
+            combined[..32].copy_from_slice(sibling);
+            combined[32..].copy_from_slice(&current_hash);
         }
+        current_hash = risc0_hasher(&combined);
+        current_index /= 2; // move to parent level
+    }
 
-        let computed_root = current_hash;
-        assert_eq!(
-            computed_root, expected_root,
-            "merkle root mismatch: coin not in current tree state"
-        );
+    let computed_root = current_hash;
+    assert_eq!(
+        computed_root, expected_root,
+        "merkle root mismatch: coin not in current tree state"
+    );
 
-        Some(serial_number)
-    } else {
-        // No serial commitment fields provided - no nullifier generation
-        None
-    };
-
-    let _validated_conditions = conditions;
-
+    // 5. Compute nullifier = hash(serial_number || program_hash)
+    // Note: serial_randomness excluded to prevent linkability with coin_commitment
+    let mut nullifier_data = Vec::with_capacity(64);
+    nullifier_data.extend_from_slice(&serial_number);
+    nullifier_data.extend_from_slice(&program_hash);
+    let nullifier = risc0_hasher(&nullifier_data);
     let end_cycles = env::cycle_count();
     let total_cycles = end_cycles.saturating_sub(start_cycles);
-
     let clvm_output = ClvmResult {
         output: output_bytes,
         cost: total_cycles,
     };
-
     env::commit(&ProofOutput {
         program_hash,
-        nullifier,
+        nullifier: Some(nullifier),
         clvm_res: clvm_output,
     });
 }

--- a/backends/risc0/guest/src/main.rs
+++ b/backends/risc0/guest/src/main.rs
@@ -4,8 +4,7 @@ use risc0_zkvm::guest::env;
 use risc0_zkvm::sha::{Impl, Sha256 as RiscSha256};
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, InputWithSerial,
-    ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -84,7 +83,7 @@ fn risc0_verify_ecdsa(
 fn main() {
     let start_cycles = env::cycle_count();
 
-    let private_inputs: InputWithSerial = env::read();
+    let private_inputs: Input = env::read();
     let (instance_bytecode, program_hash, function_table) =
         compile_chialisp_to_bytecode_with_table(
             risc0_hasher,
@@ -98,83 +97,88 @@ fn main() {
     let (output_bytes, _conditions) = evaluator
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
-    // Serial commitment protocol for spending
-    let expected_program_hash = private_inputs.program_hash;
-    assert_eq!(
-        program_hash, expected_program_hash,
-        "program_hash mismatch: cannot spend coin with different program"
-    );
-    let serial_number = private_inputs.serial_number;
-    let serial_randomness = private_inputs.serial_randomness;
-    let domain = b"clvm_zk_serial_v1.0";
-    let mut commitment_data = [0u8; 83];
-    commitment_data[..19].copy_from_slice(domain);
-    commitment_data[19..51].copy_from_slice(&serial_number);
-    commitment_data[51..83].copy_from_slice(&serial_randomness);
-    let computed_serial_commitment = risc0_hasher(&commitment_data);
 
-    let serial_commitment_expected = private_inputs.serial_commitment;
-    assert_eq!(
-        computed_serial_commitment, serial_commitment_expected,
-        "serial commitment verification failed"
-    );
-    let amount = private_inputs.amount;
-    // 3. Reconstruct and verify coin_commitment = hash(domain || program_hash || serial_commitment)
-    let coin_domain = b"clvm_zk_coin_v1.0";
-    let mut coin_data = [0u8; 17 + 32 + 8 + 32];
-    coin_data[..17].copy_from_slice(coin_domain);
-    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
-    coin_data[25..57].copy_from_slice(&program_hash);
-    coin_data[57..89].copy_from_slice(&computed_serial_commitment);
-    let computed_coin_commitment = risc0_hasher(&coin_data);
-    let coin_commitment_provided = private_inputs.coin_commitment;
-    assert_eq!(
-        computed_coin_commitment, coin_commitment_provided,
-        "coin commitment verification failed"
-    );
+    let nullifier = match private_inputs.serial_commitment_data {
+        Some(commitment_data) => {
+            let expected_program_hash = commitment_data.program_hash;
+            assert_eq!(
+                program_hash, expected_program_hash,
+                "program_hash mismatch: cannot spend coin with different program"
+            );
 
-    // 4. Verify merkle membership
-    let merkle_path = private_inputs.merkle_path;
-    let expected_root = private_inputs.merkle_root;
-    let leaf_index = private_inputs.leaf_index;
+            let serial_number = commitment_data.serial_number;
+            let serial_randomness = commitment_data.serial_randomness;
+            let domain = b"clvm_zk_serial_v1.0";
+            let mut serial_commit_data = [0u8; 83];
+            serial_commit_data[..19].copy_from_slice(domain);
+            serial_commit_data[19..51].copy_from_slice(&serial_number);
+            serial_commit_data[51..83].copy_from_slice(&serial_randomness);
+            let computed_serial_commitment = risc0_hasher(&serial_commit_data);
 
-    let mut current_hash = computed_coin_commitment;
-    let mut current_index = leaf_index;
-    for sibling in merkle_path.iter() {
-        let mut combined = [0u8; 64];
-        // position-based hashing: if index is even (left child), sibling goes right
-        if current_index % 2 == 0 {
-            combined[..32].copy_from_slice(&current_hash);
-            combined[32..].copy_from_slice(sibling);
-        } else {
-            combined[..32].copy_from_slice(sibling);
-            combined[32..].copy_from_slice(&current_hash);
+            let serial_commitment_expected = commitment_data.serial_commitment;
+            assert_eq!(
+                computed_serial_commitment, serial_commitment_expected,
+                "serial commitment verification failed"
+            );
+
+            let amount = commitment_data.amount;
+            let coin_domain = b"clvm_zk_coin_v1.0";
+            let mut coin_data = [0u8; 17 + 8 + 32 + 32];
+            coin_data[..17].copy_from_slice(coin_domain);
+            coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+            coin_data[25..57].copy_from_slice(&program_hash);
+            coin_data[57..89].copy_from_slice(&computed_serial_commitment);
+            let computed_coin_commitment = risc0_hasher(&coin_data);
+
+            let coin_commitment_provided = commitment_data.coin_commitment;
+            assert_eq!(
+                computed_coin_commitment, coin_commitment_provided,
+                "coin commitment verification failed"
+            );
+
+            let merkle_path = commitment_data.merkle_path;
+            let expected_root = commitment_data.merkle_root;
+            let leaf_index = commitment_data.leaf_index;
+
+            let mut current_hash = computed_coin_commitment;
+            let mut current_index = leaf_index;
+            for sibling in merkle_path.iter() {
+                let mut combined = [0u8; 64];
+                if current_index % 2 == 0 {
+                    combined[..32].copy_from_slice(&current_hash);
+                    combined[32..].copy_from_slice(sibling);
+                } else {
+                    combined[..32].copy_from_slice(sibling);
+                    combined[32..].copy_from_slice(&current_hash);
+                }
+                current_hash = risc0_hasher(&combined);
+                current_index /= 2;
+            }
+
+            let computed_root = current_hash;
+            assert_eq!(
+                computed_root, expected_root,
+                "merkle root mismatch: coin not in current tree state"
+            );
+
+            let mut nullifier_data = Vec::with_capacity(64);
+            nullifier_data.extend_from_slice(&serial_number);
+            nullifier_data.extend_from_slice(&program_hash);
+            Some(risc0_hasher(&nullifier_data))
         }
-        current_hash = risc0_hasher(&combined);
-        current_index /= 2; // move to parent level
-    }
+        None => None,
+    };
 
-    let computed_root = current_hash;
-    assert_eq!(
-        computed_root, expected_root,
-        "merkle root mismatch: coin not in current tree state"
-    );
-
-    // 5. Compute nullifier = hash(serial_number || program_hash)
-    // Note: serial_randomness excluded to prevent linkability with coin_commitment
-    let mut nullifier_data = Vec::with_capacity(64);
-    nullifier_data.extend_from_slice(&serial_number);
-    nullifier_data.extend_from_slice(&program_hash);
-    let nullifier = risc0_hasher(&nullifier_data);
     let end_cycles = env::cycle_count();
     let total_cycles = end_cycles.saturating_sub(start_cycles);
     let clvm_output = ClvmResult {
         output: output_bytes,
         cost: total_cycles,
     };
+
     env::commit(&ProofOutput {
         program_hash,
-        nullifier: Some(nullifier),
+        nullifier,
         clvm_res: clvm_output,
     });
 }

--- a/backends/risc0/src/lib.rs
+++ b/backends/risc0/src/lib.rs
@@ -71,15 +71,13 @@ impl Risc0Backend {
         })
     }
 
-    pub fn prove_chialisp_with_nullifier(
+    /// prove with custom input (allows serial commitment protocol)
+    pub fn prove_with_input(
         &self,
-        chialisp_source: &str,
-        program_parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
+        inputs: clvm_zk_core::Input,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use risc0_zkvm::{default_prover, ExecutorEnv};
 
-        let inputs = prepare_guest_inputs(chialisp_source, program_parameters, Some(spend_secret));
         let env = ExecutorEnv::builder()
             .write(&inputs)
             .map_err(|e| {
@@ -103,7 +101,7 @@ impl Risc0Backend {
 
         let receipt_obj = receipt.receipt;
         let result: ProofOutput = receipt_obj.journal.decode().map_err(|e| {
-            ClvmZkError::InvalidProofFormat(format!("failed to decode nullifier journal: {e}"))
+            ClvmZkError::InvalidProofFormat(format!("failed to decode journal: {e}"))
         })?;
 
         validate_nullifier_proof_output(&result, "RISC0")?;
@@ -113,8 +111,8 @@ impl Risc0Backend {
         })?;
 
         Ok(ZKClvmResult {
-            proof_output: result,
             proof_bytes,
+            proof_output: result,
         })
     }
 

--- a/backends/risc0/src/lib.rs
+++ b/backends/risc0/src/lib.rs
@@ -3,8 +3,7 @@ pub use methods::*;
 
 use borsh;
 use clvm_zk_core::backend_utils::{
-    convert_proving_error, prepare_guest_inputs, validate_nullifier_proof_output,
-    validate_proof_output,
+    convert_proving_error, validate_nullifier_proof_output, validate_proof_output,
 };
 pub use clvm_zk_core::{
     ClvmResult, ClvmZkError, Input, ProgramParameter, ProofOutput, ZKClvmResult,
@@ -34,7 +33,10 @@ impl Risc0Backend {
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use risc0_zkvm::{default_prover, ExecutorEnv};
 
-        let inputs = prepare_guest_inputs(chialisp_source, program_parameters, None);
+        let inputs = Input {
+            chialisp_source: chialisp_source.to_string(),
+            program_parameters: program_parameters.to_vec(),
+        };
         let env = ExecutorEnv::builder()
             .write(&inputs)
             .map_err(|e| {
@@ -71,10 +73,9 @@ impl Risc0Backend {
         })
     }
 
-    /// prove with custom input (allows serial commitment protocol)
     pub fn prove_with_input(
         &self,
-        inputs: clvm_zk_core::Input,
+        inputs: clvm_zk_core::InputWithSerial,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use risc0_zkvm::{default_prover, ExecutorEnv};
 

--- a/backends/risc0/src/lib.rs
+++ b/backends/risc0/src/lib.rs
@@ -36,6 +36,7 @@ impl Risc0Backend {
         let inputs = Input {
             chialisp_source: chialisp_source.to_string(),
             program_parameters: program_parameters.to_vec(),
+            serial_commitment_data: None,
         };
         let env = ExecutorEnv::builder()
             .write(&inputs)
@@ -75,7 +76,7 @@ impl Risc0Backend {
 
     pub fn prove_with_input(
         &self,
-        inputs: clvm_zk_core::InputWithSerial,
+        inputs: clvm_zk_core::Input,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use risc0_zkvm::{default_prover, ExecutorEnv};
 

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -5,8 +5,7 @@ use sp1_zkvm::io;
 extern crate alloc;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, InputWithSerial,
-    ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -81,7 +80,7 @@ fn sp1_verify_ecdsa(
 }
 
 fn main() {
-    let private_inputs: InputWithSerial = io::read();
+    let private_inputs: Input = io::read();
     let (instance_bytecode, program_hash, function_table) =
         compile_chialisp_to_bytecode_with_table(
             sp1_hasher,
@@ -96,76 +95,76 @@ fn main() {
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
 
-    // Serial commitment protocol for spending
+    let nullifier = match private_inputs.serial_commitment_data {
+        Some(commitment_data) => {
+            let expected_program_hash = commitment_data.program_hash;
+            assert_eq!(
+                program_hash, expected_program_hash,
+                "program_hash mismatch: cannot spend coin with different program"
+            );
 
-    let expected_program_hash = private_inputs.program_hash;
-    assert_eq!(
-        program_hash, expected_program_hash,
-        "program_hash mismatch: cannot spend coin with different program"
-    );
-    let serial_randomness = private_inputs.serial_randomness;
-    let serial_number = private_inputs.serial_number;
-    let domain = b"clvm_zk_serial_v1.0";
-    let mut commitment_data = [0u8; 83];
-    commitment_data[..19].copy_from_slice(domain);
-    commitment_data[19..51].copy_from_slice(&serial_number);
-    commitment_data[51..83].copy_from_slice(&serial_randomness);
-    let computed_serial_commitment = sp1_hasher(&commitment_data);
+            let serial_randomness = commitment_data.serial_randomness;
+            let serial_number = commitment_data.serial_number;
+            let domain = b"clvm_zk_serial_v1.0";
+            let mut serial_commit_data = [0u8; 83];
+            serial_commit_data[..19].copy_from_slice(domain);
+            serial_commit_data[19..51].copy_from_slice(&serial_number);
+            serial_commit_data[51..83].copy_from_slice(&serial_randomness);
+            let computed_serial_commitment = sp1_hasher(&serial_commit_data);
 
-    // Verify serial commitment and merkle membership
-    let serial_commitment_expected = private_inputs.serial_commitment;
-    assert_eq!(
-        computed_serial_commitment, serial_commitment_expected,
-        "serial commitment verification failed"
-    );
+            let serial_commitment_expected = commitment_data.serial_commitment;
+            assert_eq!(
+                computed_serial_commitment, serial_commitment_expected,
+                "serial commitment verification failed"
+            );
 
-    let serial_number = private_inputs.serial_number;
+            let amount = commitment_data.amount;
+            let coin_domain = b"clvm_zk_coin_v1.0";
+            let mut coin_data = [0u8; 17 + 8 + 32 + 32];
+            coin_data[..17].copy_from_slice(coin_domain);
+            coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+            coin_data[25..57].copy_from_slice(&program_hash);
+            coin_data[57..89].copy_from_slice(&computed_serial_commitment);
+            let computed_coin_commitment = sp1_hasher(&coin_data);
 
-    let amount = private_inputs.amount;
-    // 3. Reconstruct and verify coin_commitment = hash(domain || program_hash || serial_commitment)
-    let coin_domain = b"clvm_zk_coin_v1.0";
-    let mut coin_data = [0u8; 17 + 32 + 8 + 32];
-    coin_data[..17].copy_from_slice(coin_domain);
-    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
-    coin_data[25..57].copy_from_slice(&program_hash);
-    coin_data[57..89].copy_from_slice(&computed_serial_commitment);
-    let computed_serial_commitment = sp1_hasher(&coin_data);
+            let coin_commitment = commitment_data.coin_commitment;
+            assert_eq!(
+                computed_coin_commitment, coin_commitment,
+                "coin commitment verification failed"
+            );
 
-    assert_eq!(
-        computed_serial_commitment, serial_commitment_expected,
-        "serial commitment verification failed"
-    );
-    let coin_commitment = private_inputs.coin_commitment;
-    let merkle_path = private_inputs.merkle_path;
-    let expected_root = private_inputs.merkle_root;
-    let leaf_index = private_inputs.leaf_index;
+            let merkle_path = commitment_data.merkle_path;
+            let expected_root = commitment_data.merkle_root;
+            let leaf_index = commitment_data.leaf_index;
 
-    let mut current_hash = coin_commitment;
-    let mut current_index = leaf_index;
-    for sibling in merkle_path.iter() {
-        let mut combined = [0u8; 64];
-        // position-based hashing: if index is even (left child), sibling goes right
-        if current_index % 2 == 0 {
-            combined[..32].copy_from_slice(&current_hash);
-            combined[32..].copy_from_slice(sibling);
-        } else {
-            combined[..32].copy_from_slice(sibling);
-            combined[32..].copy_from_slice(&current_hash);
+            let mut current_hash = coin_commitment;
+            let mut current_index = leaf_index;
+            for sibling in merkle_path.iter() {
+                let mut combined = [0u8; 64];
+                if current_index % 2 == 0 {
+                    combined[..32].copy_from_slice(&current_hash);
+                    combined[32..].copy_from_slice(sibling);
+                } else {
+                    combined[..32].copy_from_slice(sibling);
+                    combined[32..].copy_from_slice(&current_hash);
+                }
+                current_hash = sp1_hasher(&combined);
+                current_index /= 2;
+            }
+
+            let computed_root = current_hash;
+            assert_eq!(
+                computed_root, expected_root,
+                "merkle root mismatch: coin not in current tree state"
+            );
+
+            let mut nullifier_data = Vec::with_capacity(64);
+            nullifier_data.extend_from_slice(&serial_number);
+            nullifier_data.extend_from_slice(&program_hash);
+            Some(sp1_hasher(&nullifier_data))
         }
-        current_hash = sp1_hasher(&combined);
-        current_index /= 2; // move to parent level
-    }
-
-    let computed_root = current_hash;
-    assert_eq!(
-        computed_root, expected_root,
-        "merkle root mismatch: coin not in current tree state"
-    );
-
-    let mut nullifier_data = Vec::with_capacity(64);
-    nullifier_data.extend_from_slice(&serial_number);
-    nullifier_data.extend_from_slice(&program_hash);
-    let nullifier = sp1_hasher(&nullifier_data);
+        None => None,
+    };
 
     let clvm_output = ClvmResult {
         output: output_bytes,
@@ -174,7 +173,7 @@ fn main() {
 
     io::commit(&ProofOutput {
         program_hash,
-        nullifier: Some(nullifier),
+        nullifier,
         clvm_res: clvm_output,
     });
 }

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -5,7 +5,8 @@ use sp1_zkvm::io;
 extern crate alloc;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, InputWithSerial,
+    ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -80,7 +81,7 @@ fn sp1_verify_ecdsa(
 }
 
 fn main() {
-    let private_inputs: Input = io::read();
+    let private_inputs: InputWithSerial = io::read();
     let (instance_bytecode, program_hash, function_table) =
         compile_chialisp_to_bytecode_with_table(
             sp1_hasher,
@@ -91,77 +92,80 @@ fn main() {
 
     let mut evaluator = ClvmEvaluator::new(sp1_hasher, sp1_verify_bls, sp1_verify_ecdsa);
     evaluator.function_table = function_table;
-    let (output_bytes, conditions) = evaluator
+    let (output_bytes, _conditions) = evaluator
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
 
     // Serial commitment protocol for spending
-    let nullifier = if let Some(serial_randomness) = private_inputs.serial_randomness {
-        // CRITICAL: Verify the program being executed matches the coin's puzzle_hash
-        let expected_puzzle_hash = private_inputs
-            .puzzle_hash
-            .expect("puzzle_hash required with serial_randomness");
-        assert_eq!(
-            program_hash, expected_puzzle_hash,
-            "program_hash mismatch: cannot spend coin with different puzzle"
-        );
-        
-        // Verify serial commitment and merkle membership
-        let serial_commitment_expected = private_inputs
-            .serial_commitment
-            .expect("serial_commitment required with serial_randomness");
-        let serial_number = private_inputs
-            .serial_number
-            .expect("serial_number required with serial_randomness");
 
-        let domain = b"clvm_zk_serial_v1.0";
-        let mut commitment_data = [0u8; 83];
-        commitment_data[..19].copy_from_slice(domain);
-        commitment_data[19..51].copy_from_slice(&serial_number);
-        commitment_data[51..83].copy_from_slice(&serial_randomness);
-        let computed_serial_commitment = sp1_hasher(&commitment_data);
+    let expected_program_hash = private_inputs.program_hash;
+    assert_eq!(
+        program_hash, expected_program_hash,
+        "program_hash mismatch: cannot spend coin with different program"
+    );
+    let serial_randomness = private_inputs.serial_randomness;
+    let serial_number = private_inputs.serial_number;
+    let domain = b"clvm_zk_serial_v1.0";
+    let mut commitment_data = [0u8; 83];
+    commitment_data[..19].copy_from_slice(domain);
+    commitment_data[19..51].copy_from_slice(&serial_number);
+    commitment_data[51..83].copy_from_slice(&serial_randomness);
+    let computed_serial_commitment = sp1_hasher(&commitment_data);
 
-        assert_eq!(
-            computed_serial_commitment, serial_commitment_expected,
-            "serial commitment verification failed"
-        );
+    // Verify serial commitment and merkle membership
+    let serial_commitment_expected = private_inputs.serial_commitment;
+    assert_eq!(
+        computed_serial_commitment, serial_commitment_expected,
+        "serial commitment verification failed"
+    );
 
-        let coin_commitment = private_inputs
-            .coin_commitment
-            .expect("coin_commitment required");
-        let merkle_path = private_inputs.merkle_path.expect("merkle_path required");
-        let expected_root = private_inputs.merkle_root.expect("merkle_root required");
-        let leaf_index = private_inputs.leaf_index.expect("leaf_index required");
+    let serial_number = private_inputs.serial_number;
 
-        let mut current_hash = coin_commitment;
-        let mut current_index = leaf_index;
-        for sibling in merkle_path.iter() {
-            let mut combined = [0u8; 64];
-            // position-based hashing: if index is even (left child), sibling goes right
-            if current_index % 2 == 0 {
-                combined[..32].copy_from_slice(&current_hash);
-                combined[32..].copy_from_slice(sibling);
-            } else {
-                combined[..32].copy_from_slice(sibling);
-                combined[32..].copy_from_slice(&current_hash);
-            }
-            current_hash = sp1_hasher(&combined);
-            current_index /= 2; // move to parent level
+    let amount = private_inputs.amount;
+    // 3. Reconstruct and verify coin_commitment = hash(domain || program_hash || serial_commitment)
+    let coin_domain = b"clvm_zk_coin_v1.0";
+    let mut coin_data = [0u8; 17 + 32 + 8 + 32];
+    coin_data[..17].copy_from_slice(coin_domain);
+    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+    coin_data[25..57].copy_from_slice(&program_hash);
+    coin_data[57..89].copy_from_slice(&computed_serial_commitment);
+    let computed_serial_commitment = sp1_hasher(&coin_data);
+
+    assert_eq!(
+        computed_serial_commitment, serial_commitment_expected,
+        "serial commitment verification failed"
+    );
+    let coin_commitment = private_inputs.coin_commitment;
+    let merkle_path = private_inputs.merkle_path;
+    let expected_root = private_inputs.merkle_root;
+    let leaf_index = private_inputs.leaf_index;
+
+    let mut current_hash = coin_commitment;
+    let mut current_index = leaf_index;
+    for sibling in merkle_path.iter() {
+        let mut combined = [0u8; 64];
+        // position-based hashing: if index is even (left child), sibling goes right
+        if current_index % 2 == 0 {
+            combined[..32].copy_from_slice(&current_hash);
+            combined[32..].copy_from_slice(sibling);
+        } else {
+            combined[..32].copy_from_slice(sibling);
+            combined[32..].copy_from_slice(&current_hash);
         }
+        current_hash = sp1_hasher(&combined);
+        current_index /= 2; // move to parent level
+    }
 
-        let computed_root = current_hash;
-        assert_eq!(
-            computed_root, expected_root,
-            "merkle root mismatch: coin not in current tree state"
-        );
+    let computed_root = current_hash;
+    assert_eq!(
+        computed_root, expected_root,
+        "merkle root mismatch: coin not in current tree state"
+    );
 
-        Some(serial_number)
-    } else {
-        // No serial commitment fields provided - no nullifier generation
-        None
-    };
-
-    let _validated_conditions = conditions;
+    let mut nullifier_data = Vec::with_capacity(64);
+    nullifier_data.extend_from_slice(&serial_number);
+    nullifier_data.extend_from_slice(&program_hash);
+    let nullifier = sp1_hasher(&nullifier_data);
 
     let clvm_output = ClvmResult {
         output: output_bytes,
@@ -170,7 +174,7 @@ fn main() {
 
     io::commit(&ProofOutput {
         program_hash,
-        nullifier,
+        nullifier: Some(nullifier),
         clvm_res: clvm_output,
     });
 }

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -5,8 +5,8 @@ use sp1_zkvm::io;
 extern crate alloc;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode_with_table, generate_nullifier, ClvmEvaluator, ClvmResult, Input,
-    ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput,
+    BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -96,9 +96,53 @@ fn main() {
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
 
-    let computed_nullifier = match private_inputs.spend_secret {
-        Some(spend_secret) => generate_nullifier(sp1_hasher, &spend_secret, &program_hash),
-        None => [0u8; 32],
+    // Serial commitment protocol for spending (optional)
+    let nullifier = if let Some(serial_randomness) = private_inputs.serial_randomness {
+        // Verify serial commitment and merkle membership
+        let serial_commitment_expected = private_inputs
+            .serial_commitment
+            .expect("serial_commitment required with serial_randomness");
+        let serial_number = private_inputs.spend_secret.expect("serial_number required with serial_randomness");
+
+        let domain = b"clvm_zk_serial_v1.0";
+        let mut commitment_data = [0u8; 83];
+        commitment_data[..19].copy_from_slice(domain);
+        commitment_data[19..51].copy_from_slice(&serial_number);
+        commitment_data[51..83].copy_from_slice(&serial_randomness);
+        let computed_serial_commitment = sp1_hasher(&commitment_data);
+
+        assert_eq!(
+            computed_serial_commitment, serial_commitment_expected,
+            "serial commitment verification failed"
+        );
+
+        let coin_commitment = private_inputs.coin_commitment.expect("coin_commitment required");
+        let merkle_path = private_inputs.merkle_path.expect("merkle_path required");
+        let expected_root = private_inputs.merkle_root.expect("merkle_root required");
+
+        let mut current_hash = coin_commitment;
+        for sibling in merkle_path.iter() {
+            let mut combined = [0u8; 64];
+            if current_hash < *sibling {
+                combined[..32].copy_from_slice(&current_hash);
+                combined[32..].copy_from_slice(sibling);
+            } else {
+                combined[..32].copy_from_slice(sibling);
+                combined[32..].copy_from_slice(&current_hash);
+            }
+            current_hash = sp1_hasher(&combined);
+        }
+
+        let computed_root = current_hash;
+        assert_eq!(
+            computed_root, expected_root,
+            "merkle root mismatch: coin not in current tree state"
+        );
+
+        Some(serial_number)
+    } else {
+        // No nullifier (e.g., BLS tests, signature verification tests)
+        private_inputs.spend_secret
     };
 
     let _validated_conditions = conditions;
@@ -110,11 +154,7 @@ fn main() {
 
     io::commit(&ProofOutput {
         program_hash,
-        nullifier: if private_inputs.spend_secret.is_some() {
-            Some(computed_nullifier)
-        } else {
-            None
-        },
+        nullifier,
         clvm_res: clvm_output,
     });
 }

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -95,14 +95,23 @@ fn main() {
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
 
-    // Serial commitment protocol for spending (optional)
+    // Serial commitment protocol for spending
     let nullifier = if let Some(serial_randomness) = private_inputs.serial_randomness {
+        // CRITICAL: Verify the program being executed matches the coin's puzzle_hash
+        let expected_puzzle_hash = private_inputs
+            .puzzle_hash
+            .expect("puzzle_hash required with serial_randomness");
+        assert_eq!(
+            program_hash, expected_puzzle_hash,
+            "program_hash mismatch: cannot spend coin with different puzzle"
+        );
+        
         // Verify serial commitment and merkle membership
         let serial_commitment_expected = private_inputs
             .serial_commitment
             .expect("serial_commitment required with serial_randomness");
         let serial_number = private_inputs
-            .spend_secret
+            .serial_number
             .expect("serial_number required with serial_randomness");
 
         let domain = b"clvm_zk_serial_v1.0";
@@ -148,8 +157,8 @@ fn main() {
 
         Some(serial_number)
     } else {
-        // No nullifier (e.g., BLS tests, signature verification tests)
-        private_inputs.spend_secret
+        // No serial commitment fields provided - no nullifier generation
+        None
     };
 
     let _validated_conditions = conditions;

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -5,8 +5,7 @@ use sp1_zkvm::io;
 extern crate alloc;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput,
-    BLS_DST,
+    compile_chialisp_to_bytecode_with_table, ClvmEvaluator, ClvmResult, Input, ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -102,7 +101,9 @@ fn main() {
         let serial_commitment_expected = private_inputs
             .serial_commitment
             .expect("serial_commitment required with serial_randomness");
-        let serial_number = private_inputs.spend_secret.expect("serial_number required with serial_randomness");
+        let serial_number = private_inputs
+            .spend_secret
+            .expect("serial_number required with serial_randomness");
 
         let domain = b"clvm_zk_serial_v1.0";
         let mut commitment_data = [0u8; 83];
@@ -116,7 +117,9 @@ fn main() {
             "serial commitment verification failed"
         );
 
-        let coin_commitment = private_inputs.coin_commitment.expect("coin_commitment required");
+        let coin_commitment = private_inputs
+            .coin_commitment
+            .expect("coin_commitment required");
         let merkle_path = private_inputs.merkle_path.expect("merkle_path required");
         let expected_root = private_inputs.merkle_root.expect("merkle_root required");
 

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -122,11 +122,14 @@ fn main() {
             .expect("coin_commitment required");
         let merkle_path = private_inputs.merkle_path.expect("merkle_path required");
         let expected_root = private_inputs.merkle_root.expect("merkle_root required");
+        let leaf_index = private_inputs.leaf_index.expect("leaf_index required");
 
         let mut current_hash = coin_commitment;
+        let mut current_index = leaf_index;
         for sibling in merkle_path.iter() {
             let mut combined = [0u8; 64];
-            if current_hash < *sibling {
+            // position-based hashing: if index is even (left child), sibling goes right
+            if current_index % 2 == 0 {
                 combined[..32].copy_from_slice(&current_hash);
                 combined[32..].copy_from_slice(sibling);
             } else {
@@ -134,6 +137,7 @@ fn main() {
                 combined[32..].copy_from_slice(&current_hash);
             }
             current_hash = sp1_hasher(&combined);
+            current_index /= 2; // move to parent level
         }
 
         let computed_root = current_hash;

--- a/backends/sp1/src/lib.rs
+++ b/backends/sp1/src/lib.rs
@@ -6,8 +6,7 @@ pub use clvm_zk_core::{
 };
 
 use clvm_zk_core::backend_utils::{
-    convert_proving_error, prepare_guest_inputs, validate_nullifier_proof_output,
-    validate_proof_output,
+    convert_proving_error, validate_nullifier_proof_output, validate_proof_output,
 };
 
 use sp1_sdk::SP1ProofMode;
@@ -60,7 +59,10 @@ impl Sp1Backend {
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use sp1_sdk::{ProverClient, SP1Stdin};
 
-        let inputs = prepare_guest_inputs(chialisp_source, program_parameters, None);
+        let inputs = Input {
+            chialisp_source: chialisp_source.to_string(),
+            program_parameters: program_parameters.to_vec(),
+        };
 
         let mut stdin = SP1Stdin::new();
         stdin.write(&inputs);
@@ -105,7 +107,7 @@ impl Sp1Backend {
 
     pub fn prove_with_input(
         &self,
-        inputs: clvm_zk_core::Input,
+        inputs: clvm_zk_core::InputWithSerial,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use sp1_sdk::{ProverClient, SP1Stdin};
         let mut stdin = SP1Stdin::new();

--- a/backends/sp1/src/lib.rs
+++ b/backends/sp1/src/lib.rs
@@ -103,16 +103,11 @@ impl Sp1Backend {
         })
     }
 
-    pub fn prove_chialisp_with_nullifier(
+    pub fn prove_with_input(
         &self,
-        chialisp_source: &str,
-        program_parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
+        inputs: clvm_zk_core::Input,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use sp1_sdk::{ProverClient, SP1Stdin};
-
-        let inputs = prepare_guest_inputs(chialisp_source, program_parameters, Some(spend_secret));
-
         let mut stdin = SP1Stdin::new();
         stdin.write(&inputs);
 

--- a/backends/sp1/src/lib.rs
+++ b/backends/sp1/src/lib.rs
@@ -62,6 +62,7 @@ impl Sp1Backend {
         let inputs = Input {
             chialisp_source: chialisp_source.to_string(),
             program_parameters: program_parameters.to_vec(),
+            serial_commitment_data: None,
         };
 
         let mut stdin = SP1Stdin::new();
@@ -107,7 +108,7 @@ impl Sp1Backend {
 
     pub fn prove_with_input(
         &self,
-        inputs: clvm_zk_core::InputWithSerial,
+        inputs: clvm_zk_core::Input,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         use sp1_sdk::{ProverClient, SP1Stdin};
         let mut stdin = SP1Stdin::new();

--- a/clvm_zk_core/src/backend_utils.rs
+++ b/clvm_zk_core/src/backend_utils.rs
@@ -20,6 +20,7 @@ pub fn prepare_guest_inputs(
         coin_commitment: None,
         serial_commitment: None,
         merkle_root: None,
+        leaf_index: None,
         puzzle_hash: None,
     }
 }
@@ -35,6 +36,7 @@ pub fn prepare_guest_inputs_with_serial(
     coin_commitment: [u8; 32],
     serial_commitment: [u8; 32],
     merkle_root: [u8; 32],
+    leaf_index: usize,
     puzzle_hash: [u8; 32],
 ) -> Input {
     Input {
@@ -46,6 +48,7 @@ pub fn prepare_guest_inputs_with_serial(
         coin_commitment: Some(coin_commitment),
         serial_commitment: Some(serial_commitment),
         merkle_root: Some(merkle_root),
+        leaf_index: Some(leaf_index),
         puzzle_hash: Some(puzzle_hash),
     }
 }

--- a/clvm_zk_core/src/backend_utils.rs
+++ b/clvm_zk_core/src/backend_utils.rs
@@ -1,10 +1,10 @@
 //! Common utilities shared between different zkVM backends
 
 use crate::{ClvmZkError, Input, ProgramParameter, ProofOutput};
-use alloc::{format, string::ToString};
+use alloc::{format, string::ToString, vec::Vec};
 use core::fmt::Display;
 
-/// Prepare inputs for guest-side compilation
+/// Prepare inputs for guest-side compilation (old protocol)
 pub fn prepare_guest_inputs(
     chialisp_source: &str,
     program_parameters: &[ProgramParameter],
@@ -14,6 +14,38 @@ pub fn prepare_guest_inputs(
         chialisp_source: chialisp_source.to_string(),
         program_parameters: program_parameters.to_vec(),
         spend_secret,
+        // Serial commitment protocol fields - default to None for non-spending use cases
+        serial_randomness: None,
+        merkle_path: None,
+        coin_commitment: None,
+        serial_commitment: None,
+        merkle_root: None,
+        puzzle_hash: None,
+    }
+}
+
+/// Prepare inputs with serial commitment protocol (v2.0)
+pub fn prepare_guest_inputs_with_serial(
+    chialisp_source: &str,
+    program_parameters: &[ProgramParameter],
+    serial_number: [u8; 32],
+    serial_randomness: [u8; 32],
+    merkle_path: Vec<[u8; 32]>,
+    coin_commitment: [u8; 32],
+    serial_commitment: [u8; 32],
+    merkle_root: [u8; 32],
+    puzzle_hash: [u8; 32],
+) -> Input {
+    Input {
+        chialisp_source: chialisp_source.to_string(),
+        program_parameters: program_parameters.to_vec(),
+        spend_secret: Some(serial_number), // serial_number is used as spend_secret in new protocol
+        serial_randomness: Some(serial_randomness),
+        merkle_path: Some(merkle_path),
+        coin_commitment: Some(coin_commitment),
+        serial_commitment: Some(serial_commitment),
+        merkle_root: Some(merkle_root),
+        puzzle_hash: Some(puzzle_hash),
     }
 }
 

--- a/clvm_zk_core/src/backend_utils.rs
+++ b/clvm_zk_core/src/backend_utils.rs
@@ -1,36 +1,8 @@
 //! Common utilities shared between different zkVM backends
 
-use crate::{ClvmZkError, Input, ProgramParameter, ProofOutput};
-use alloc::{format, string::ToString, vec::Vec};
+use crate::{ClvmZkError, ProofOutput};
+use alloc::{format, string::ToString};
 use core::fmt::Display;
-
-/// Prepare inputs with serial commitment protocol (v2.0)
-#[allow(clippy::too_many_arguments)]
-pub fn prepare_guest_inputs_with_serial(
-    chialisp_source: &str,
-    program_parameters: &[ProgramParameter],
-    serial_number: [u8; 32],
-    serial_randomness: [u8; 32],
-    merkle_path: Vec<[u8; 32]>,
-    coin_commitment: [u8; 32],
-    serial_commitment: [u8; 32],
-    merkle_root: [u8; 32],
-    leaf_index: usize,
-    puzzle_hash: [u8; 32],
-) -> Input {
-    Input {
-        chialisp_source: chialisp_source.to_string(),
-        program_parameters: program_parameters.to_vec(),
-        serial_number: Some(serial_number),
-        serial_randomness: Some(serial_randomness),
-        merkle_path: Some(merkle_path),
-        coin_commitment: Some(coin_commitment),
-        serial_commitment: Some(serial_commitment),
-        merkle_root: Some(merkle_root),
-        leaf_index: Some(leaf_index),
-        puzzle_hash: Some(puzzle_hash),
-    }
-}
 
 /// Convert proving errors from zkVM into clean user-facing error messages
 pub fn convert_proving_error(error: impl Display, backend_name: &str) -> ClvmZkError {

--- a/clvm_zk_core/src/backend_utils.rs
+++ b/clvm_zk_core/src/backend_utils.rs
@@ -25,6 +25,7 @@ pub fn prepare_guest_inputs(
 }
 
 /// Prepare inputs with serial commitment protocol (v2.0)
+#[allow(clippy::too_many_arguments)]
 pub fn prepare_guest_inputs_with_serial(
     chialisp_source: &str,
     program_parameters: &[ProgramParameter],

--- a/clvm_zk_core/src/backend_utils.rs
+++ b/clvm_zk_core/src/backend_utils.rs
@@ -4,27 +4,6 @@ use crate::{ClvmZkError, Input, ProgramParameter, ProofOutput};
 use alloc::{format, string::ToString, vec::Vec};
 use core::fmt::Display;
 
-/// Prepare inputs for guest-side compilation (old protocol)
-pub fn prepare_guest_inputs(
-    chialisp_source: &str,
-    program_parameters: &[ProgramParameter],
-    spend_secret: Option<[u8; 32]>,
-) -> Input {
-    Input {
-        chialisp_source: chialisp_source.to_string(),
-        program_parameters: program_parameters.to_vec(),
-        spend_secret,
-        // Serial commitment protocol fields - default to None for non-spending use cases
-        serial_randomness: None,
-        merkle_path: None,
-        coin_commitment: None,
-        serial_commitment: None,
-        merkle_root: None,
-        leaf_index: None,
-        puzzle_hash: None,
-    }
-}
-
 /// Prepare inputs with serial commitment protocol (v2.0)
 #[allow(clippy::too_many_arguments)]
 pub fn prepare_guest_inputs_with_serial(
@@ -42,7 +21,7 @@ pub fn prepare_guest_inputs_with_serial(
     Input {
         chialisp_source: chialisp_source.to_string(),
         program_parameters: program_parameters.to_vec(),
-        spend_secret: Some(serial_number), // serial_number is used as spend_secret in new protocol
+        serial_number: Some(serial_number),
         serial_randomness: Some(serial_randomness),
         merkle_path: Some(merkle_path),
         coin_commitment: Some(coin_commitment),

--- a/clvm_zk_core/src/coin_commitment.rs
+++ b/clvm_zk_core/src/coin_commitment.rs
@@ -1,0 +1,275 @@
+//! coin commitment structures for nullifier-based privacy
+//!
+//! - serial_commitment: hides the serial_number and randomness used for spending
+//! - coin_commitment: commits to the full coin (amount, puzzle, serial_commitment)
+//! - nullifier: the serial_number, revealed only when spending to prevent double-spends
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+/// commitment to a serial number with blinding randomness
+///
+/// binds a coin to specific values that must be revealed when spending
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SerialCommitment(pub [u8; 32]);
+
+impl SerialCommitment {
+    /// create commitment from raw bytes
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        SerialCommitment(bytes)
+    }
+
+    /// get raw bytes
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// compute commitment: hash(domain || serial_number || serial_randomness)
+    pub fn compute(
+        serial_number: &[u8; 32],
+        serial_randomness: &[u8; 32],
+        hasher: fn(&[u8]) -> [u8; 32],
+    ) -> Self {
+        const DOMAIN: &[u8] = b"clvm_zk_serial_v1.0";
+
+        let mut data = Vec::with_capacity(DOMAIN.len() + 64);
+        data.extend_from_slice(DOMAIN);
+        data.extend_from_slice(serial_number);
+        data.extend_from_slice(serial_randomness);
+
+        SerialCommitment(hasher(&data))
+    }
+
+    /// verify that a commitment matches given serial_number and serial_randomness
+    pub fn verify(
+        &self,
+        serial_number: &[u8; 32],
+        serial_randomness: &[u8; 32],
+        hasher: fn(&[u8]) -> [u8; 32],
+    ) -> bool {
+        let computed = Self::compute(serial_number, serial_randomness, hasher);
+        computed == *self
+    }
+}
+
+
+/// commitment to full coin data
+///
+/// used as a leaf in the global merkle tree to prove coin existence
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoinCommitment(pub [u8; 32]);
+
+impl CoinCommitment {
+    /// create commitment from raw bytes
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        CoinCommitment(bytes)
+    }
+
+    /// get raw bytes
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// compute commitment: hash(domain || amount || puzzle_hash || serial_commitment)
+    pub fn compute(
+        amount: u64,
+        puzzle_hash: &[u8; 32],
+        serial_commitment: &SerialCommitment,
+        hasher: fn(&[u8]) -> [u8; 32],
+    ) -> Self {
+        const DOMAIN: &[u8] = b"clvm_zk_coin_v1.0";
+
+        let mut data = Vec::with_capacity(DOMAIN.len() + 8 + 64);
+        data.extend_from_slice(DOMAIN);
+        data.extend_from_slice(&amount.to_be_bytes());
+        data.extend_from_slice(puzzle_hash);
+        data.extend_from_slice(serial_commitment.as_bytes());
+
+        CoinCommitment(hasher(&data))
+    }
+}
+
+
+/// wallet storage for coin secrets
+///
+/// stores the private information needed to spend a coin.
+/// CRITICAL: losing these values = permanent loss of funds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoinSecrets {
+    /// the serial number - becomes the nullifier when spending
+    pub serial_number: [u8; 32],
+    
+    /// randomness used to blind the serial commitment
+    pub serial_randomness: [u8; 32],
+}
+
+impl CoinSecrets {
+    /// create new coin secrets with explicit values
+    pub fn new(serial_number: [u8; 32], serial_randomness: [u8; 32]) -> Self {
+        CoinSecrets {
+            serial_number,
+            serial_randomness,
+        }
+    }
+
+    /// create from 64-byte value (first 32 bytes = serial_number, last 32 = randomness)
+    pub fn from_bytes(bytes: [u8; 64]) -> Self {
+        let mut serial_number = [0u8; 32];
+        let mut serial_randomness = [0u8; 32];
+        serial_number.copy_from_slice(&bytes[..32]);
+        serial_randomness.copy_from_slice(&bytes[32..]);
+        Self::new(serial_number, serial_randomness)
+    }
+
+    /// compute the serial commitment for these secrets
+    pub fn serial_commitment(&self, hasher: fn(&[u8]) -> [u8; 32]) -> SerialCommitment {
+        SerialCommitment::compute(&self.serial_number, &self.serial_randomness, hasher)
+    }
+
+    /// get the nullifier (serial_number, revealed when spending)
+    pub fn nullifier(&self) -> [u8; 32] {
+        self.serial_number
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_hasher(data: &[u8]) -> [u8; 32] {
+        // simple xor-based test hasher
+        let mut result = [0u8; 32];
+        for (i, byte) in data.iter().enumerate() {
+            result[i % 32] ^= byte;
+        }
+        result
+    }
+
+    #[test]
+    fn test_serial_commitment_compute() {
+        let serial_number = [1u8; 32];
+        let serial_randomness = [2u8; 32];
+
+        let commitment = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
+
+        // verify it produces consistent output
+        let commitment2 = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
+        assert_eq!(commitment, commitment2);
+    }
+
+    #[test]
+    fn test_serial_commitment_verify() {
+        let serial_number = [1u8; 32];
+        let serial_randomness = [2u8; 32];
+
+        let commitment = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
+
+        // correct values verify
+        assert!(commitment.verify(&serial_number, &serial_randomness, test_hasher));
+
+        // wrong serial_number fails
+        let wrong_serial = [99u8; 32];
+        assert!(!commitment.verify(&wrong_serial, &serial_randomness, test_hasher));
+
+        // wrong randomness fails
+        let wrong_randomness = [99u8; 32];
+        assert!(!commitment.verify(&serial_number, &wrong_randomness, test_hasher));
+    }
+
+    #[test]
+    fn test_different_serials_different_commitments() {
+        let serial_randomness = [2u8; 32];
+        
+        let serial1 = [1u8; 32];
+        let serial2 = [3u8; 32];
+
+        let commitment1 = SerialCommitment::compute(&serial1, &serial_randomness, test_hasher);
+        let commitment2 = SerialCommitment::compute(&serial2, &serial_randomness, test_hasher);
+
+        assert_ne!(commitment1, commitment2);
+    }
+
+    #[test]
+    fn test_different_randomness_different_commitments() {
+        let serial_number = [1u8; 32];
+        
+        let randomness1 = [2u8; 32];
+        let randomness2 = [3u8; 32];
+
+        let commitment1 = SerialCommitment::compute(&serial_number, &randomness1, test_hasher);
+        let commitment2 = SerialCommitment::compute(&serial_number, &randomness2, test_hasher);
+
+        assert_ne!(commitment1, commitment2);
+    }
+
+    #[test]
+    fn test_coin_commitment_compute() {
+        let amount = 1000u64;
+        let puzzle_hash = [5u8; 32];
+        let serial_commitment = SerialCommitment([6u8; 32]);
+
+        let commitment = CoinCommitment::compute(
+            amount,
+            &puzzle_hash,
+            &serial_commitment,
+            test_hasher,
+        );
+
+        // verify consistent
+        let commitment2 = CoinCommitment::compute(
+            amount,
+            &puzzle_hash,
+            &serial_commitment,
+            test_hasher,
+        );
+        assert_eq!(commitment, commitment2);
+    }
+
+    #[test]
+    fn test_different_amounts_different_commitments() {
+        let puzzle_hash = [5u8; 32];
+        let serial_commitment = SerialCommitment([6u8; 32]);
+
+        let commitment1 = CoinCommitment::compute(1000, &puzzle_hash, &serial_commitment, test_hasher);
+        let commitment2 = CoinCommitment::compute(2000, &puzzle_hash, &serial_commitment, test_hasher);
+
+        assert_ne!(commitment1, commitment2);
+    }
+
+    #[test]
+    fn test_coin_secrets_commitment() {
+        let serial_number = [1u8; 32];
+        let serial_randomness = [2u8; 32];
+        let secrets = CoinSecrets::new(serial_number, serial_randomness);
+
+        let commitment1 = secrets.serial_commitment(test_hasher);
+        let commitment2 = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
+
+        assert_eq!(commitment1, commitment2);
+    }
+
+    #[test]
+    fn test_coin_secrets_nullifier() {
+        let serial_number = [42u8; 32];
+        let serial_randomness = [99u8; 32];
+        let secrets = CoinSecrets::new(serial_number, serial_randomness);
+
+        // nullifier is the serial_number
+        assert_eq!(secrets.nullifier(), serial_number);
+    }
+
+    #[test]
+    fn test_coin_secrets_from_bytes() {
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&[1u8; 32]);
+        bytes[32..].copy_from_slice(&[2u8; 32]);
+
+        let secrets = CoinSecrets::from_bytes(bytes);
+
+        assert_eq!(secrets.serial_number, [1u8; 32]);
+        assert_eq!(secrets.serial_randomness, [2u8; 32]);
+    }
+}

--- a/clvm_zk_core/src/coin_commitment.rs
+++ b/clvm_zk_core/src/coin_commitment.rs
@@ -55,7 +55,6 @@ impl SerialCommitment {
     }
 }
 
-
 /// commitment to full coin data
 ///
 /// used as a leaf in the global merkle tree to prove coin existence
@@ -92,7 +91,6 @@ impl CoinCommitment {
     }
 }
 
-
 /// wallet storage for coin secrets
 ///
 /// stores the private information needed to spend a coin.
@@ -101,7 +99,7 @@ impl CoinCommitment {
 pub struct CoinSecrets {
     /// the serial number - becomes the nullifier when spending
     pub serial_number: [u8; 32],
-    
+
     /// randomness used to blind the serial commitment
     pub serial_randomness: [u8; 32],
 }
@@ -156,7 +154,8 @@ mod tests {
         let commitment = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
 
         // verify it produces consistent output
-        let commitment2 = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
+        let commitment2 =
+            SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
         assert_eq!(commitment, commitment2);
     }
 
@@ -182,7 +181,7 @@ mod tests {
     #[test]
     fn test_different_serials_different_commitments() {
         let serial_randomness = [2u8; 32];
-        
+
         let serial1 = [1u8; 32];
         let serial2 = [3u8; 32];
 
@@ -195,7 +194,7 @@ mod tests {
     #[test]
     fn test_different_randomness_different_commitments() {
         let serial_number = [1u8; 32];
-        
+
         let randomness1 = [2u8; 32];
         let randomness2 = [3u8; 32];
 
@@ -211,20 +210,12 @@ mod tests {
         let puzzle_hash = [5u8; 32];
         let serial_commitment = SerialCommitment([6u8; 32]);
 
-        let commitment = CoinCommitment::compute(
-            amount,
-            &puzzle_hash,
-            &serial_commitment,
-            test_hasher,
-        );
+        let commitment =
+            CoinCommitment::compute(amount, &puzzle_hash, &serial_commitment, test_hasher);
 
         // verify consistent
-        let commitment2 = CoinCommitment::compute(
-            amount,
-            &puzzle_hash,
-            &serial_commitment,
-            test_hasher,
-        );
+        let commitment2 =
+            CoinCommitment::compute(amount, &puzzle_hash, &serial_commitment, test_hasher);
         assert_eq!(commitment, commitment2);
     }
 
@@ -233,8 +224,10 @@ mod tests {
         let puzzle_hash = [5u8; 32];
         let serial_commitment = SerialCommitment([6u8; 32]);
 
-        let commitment1 = CoinCommitment::compute(1000, &puzzle_hash, &serial_commitment, test_hasher);
-        let commitment2 = CoinCommitment::compute(2000, &puzzle_hash, &serial_commitment, test_hasher);
+        let commitment1 =
+            CoinCommitment::compute(1000, &puzzle_hash, &serial_commitment, test_hasher);
+        let commitment2 =
+            CoinCommitment::compute(2000, &puzzle_hash, &serial_commitment, test_hasher);
 
         assert_ne!(commitment1, commitment2);
     }
@@ -246,7 +239,8 @@ mod tests {
         let secrets = CoinSecrets::new(serial_number, serial_randomness);
 
         let commitment1 = secrets.serial_commitment(test_hasher);
-        let commitment2 = SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
+        let commitment2 =
+            SerialCommitment::compute(&serial_number, &serial_randomness, test_hasher);
 
         assert_eq!(commitment1, commitment2);
     }

--- a/clvm_zk_core/src/lib.rs
+++ b/clvm_zk_core/src/lib.rs
@@ -12,6 +12,8 @@ use sha2::{Digest, Sha256};
 pub mod backend_utils;
 pub mod chialisp;
 pub mod clvm_parser;
+pub mod coin_commitment;
+pub mod merkle;
 pub mod operators;
 pub mod types;
 
@@ -1376,18 +1378,6 @@ pub fn hash_data(data: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(data);
     hasher.finalize().into()
-}
-
-pub fn generate_nullifier(
-    hasher: Hasher,
-    spend_secret: &[u8; 32],
-    puzzle_hash: &[u8; 32],
-) -> [u8; 32] {
-    let mut combined = Vec::with_capacity(64 + 32);
-    combined.extend_from_slice(b"clvm_zk_nullifier_v1.0");
-    combined.extend_from_slice(spend_secret);
-    combined.extend_from_slice(puzzle_hash);
-    hasher(&combined)
 }
 
 /// encode a clvmvalue as clvm bytes following the standard serialization format

--- a/clvm_zk_core/src/merkle.rs
+++ b/clvm_zk_core/src/merkle.rs
@@ -1,0 +1,348 @@
+//! sparse merkle tree for coin commitment tracking
+//!
+//! provides authenticated membership proofs for coins in the utxo set.
+//! uses a sparse merkle tree where leaves are coin commitments.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
+
+/// sparse merkle tree for tracking coin commitments
+///
+/// maintains a merkle tree where each leaf is a coin commitment.
+/// allows efficient generation of membership proofs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SparseMerkleTree {
+    /// tree leaves (coin commitments)
+    leaves: Vec<[u8; 32]>,
+
+    /// cached merkle root
+    root: [u8; 32],
+
+    /// tree depth (determines max capacity = 2^depth)
+    depth: usize,
+
+    /// empty node hashes at each level (for sparse tree optimization)
+    empty_hashes: Vec<[u8; 32]>,
+}
+
+impl SparseMerkleTree {
+    /// create new sparse merkle tree with given depth
+    pub fn new(depth: usize, hasher: fn(&[u8]) -> [u8; 32]) -> Self {
+        // precompute empty node hashes for each level
+        let mut empty_hashes = Vec::with_capacity(depth + 1);
+
+        // level 0 (leaves): empty leaf = hash("EMPTY_LEAF")
+        empty_hashes.push(hasher(b"EMPTY_LEAF"));
+
+        // higher levels: empty_node[i] = hash(empty_node[i-1] || empty_node[i-1])
+        for i in 0..depth {
+            let prev = empty_hashes[i];
+            let mut combined = Vec::with_capacity(64);
+            combined.extend_from_slice(&prev);
+            combined.extend_from_slice(&prev);
+            empty_hashes.push(hasher(&combined));
+        }
+
+        let root = empty_hashes[depth];
+
+        Self {
+            leaves: Vec::new(),
+            root,
+            depth,
+            empty_hashes,
+        }
+    }
+
+    /// insert a new coin commitment and return its leaf index
+    pub fn insert(&mut self, commitment: [u8; 32], hasher: fn(&[u8]) -> [u8; 32]) -> usize {
+        let index = self.leaves.len();
+        self.leaves.push(commitment);
+
+        // recompute root
+        self.root = self.compute_root(hasher);
+
+        index
+    }
+
+    /// get current merkle root
+    pub fn root(&self) -> [u8; 32] {
+        self.root
+    }
+
+    /// get number of leaves
+    pub fn len(&self) -> usize {
+        self.leaves.len()
+    }
+
+    /// check if tree is empty
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
+    /// generate authentication path (merkle proof) for a leaf
+    pub fn generate_proof(&self, leaf_index: usize, hasher: fn(&[u8]) -> [u8; 32]) -> Result<MerkleProof, &'static str> {
+        if leaf_index >= self.leaves.len() {
+            return Err("leaf index out of bounds");
+        }
+
+        let mut path = Vec::new();
+        let mut current_index = leaf_index;
+
+        // for each level, collect the sibling hash
+        for level in 0..self.depth {
+            let sibling_index = current_index ^ 1; // flip last bit to get sibling
+
+            let sibling_hash = if sibling_index < self.leaves.len() {
+                // sibling exists, compute its hash at this level
+                self.compute_node_hash(sibling_index, level, hasher)
+            } else {
+                // sibling is empty, use precomputed empty hash
+                self.empty_hashes[level]
+            };
+
+            path.push(sibling_hash);
+            current_index >>= 1; // move up one level
+        }
+
+        Ok(MerkleProof {
+            leaf_index,
+            leaf_value: self.leaves[leaf_index],
+            path,
+        })
+    }
+
+    /// verify a merkle proof against the current root
+    pub fn verify_proof(&self, proof: &MerkleProof, hasher: fn(&[u8]) -> [u8; 32]) -> bool {
+        let computed_root = proof.compute_root(hasher);
+        computed_root == self.root
+    }
+
+    /// compute hash of a node at given index and level
+    fn compute_node_hash(&self, index: usize, level: usize, hasher: fn(&[u8]) -> [u8; 32]) -> [u8; 32] {
+        if level == 0 {
+            // base case: leaf level
+            if index < self.leaves.len() {
+                self.leaves[index]
+            } else {
+                self.empty_hashes[0]
+            }
+        } else {
+            // recursive case: internal node
+            let left_child = index << 1;
+            let right_child = left_child + 1;
+
+            let left_hash = self.compute_node_hash(left_child, level - 1, hasher);
+            let right_hash = self.compute_node_hash(right_child, level - 1, hasher);
+
+            let mut combined = Vec::with_capacity(64);
+            combined.extend_from_slice(&left_hash);
+            combined.extend_from_slice(&right_hash);
+            hasher(&combined)
+        }
+    }
+
+    /// compute current merkle root from leaves
+    fn compute_root(&self, hasher: fn(&[u8]) -> [u8; 32]) -> [u8; 32] {
+        if self.leaves.is_empty() {
+            return self.empty_hashes[self.depth];
+        }
+
+        // compute root by hashing up from leaves
+        self.compute_node_hash(0, self.depth, hasher)
+    }
+}
+
+/// merkle proof for proving membership of a leaf
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MerkleProof {
+    /// index of the leaf in the tree
+    pub leaf_index: usize,
+
+    /// value of the leaf (coin commitment)
+    pub leaf_value: [u8; 32],
+
+    /// authentication path (sibling hashes from leaf to root)
+    pub path: Vec<[u8; 32]>,
+}
+
+impl MerkleProof {
+    /// compute the merkle root from this proof
+    pub fn compute_root(&self, hasher: fn(&[u8]) -> [u8; 32]) -> [u8; 32] {
+        let mut current_hash = self.leaf_value;
+        let mut current_index = self.leaf_index;
+
+        // hash up the tree using the authentication path
+        for sibling in &self.path {
+            let mut combined = Vec::with_capacity(64);
+
+            // order matters: if index is even, we're on the left
+            if current_index & 1 == 0 {
+                // left child: hash(current || sibling)
+                combined.extend_from_slice(&current_hash);
+                combined.extend_from_slice(sibling);
+            } else {
+                // right child: hash(sibling || current)
+                combined.extend_from_slice(sibling);
+                combined.extend_from_slice(&current_hash);
+            }
+
+            current_hash = hasher(&combined);
+            current_index >>= 1;
+        }
+
+        current_hash
+    }
+
+    /// verify this proof against a given root
+    pub fn verify(&self, root: &[u8; 32], hasher: fn(&[u8]) -> [u8; 32]) -> bool {
+        let computed_root = self.compute_root(hasher);
+        &computed_root == root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_hasher(data: &[u8]) -> [u8; 32] {
+        // simple test hasher: xor all bytes
+        let mut result = [0u8; 32];
+        for (i, byte) in data.iter().enumerate() {
+            result[i % 32] ^= byte;
+        }
+        result
+    }
+
+    #[test]
+    fn test_empty_tree() {
+        let tree = SparseMerkleTree::new(4, test_hasher);
+        assert_eq!(tree.len(), 0);
+        assert!(tree.is_empty());
+
+        // root should be deterministic for empty tree
+        let empty_root = tree.root();
+        let tree2 = SparseMerkleTree::new(4, test_hasher);
+        assert_eq!(empty_root, tree2.root());
+    }
+
+    #[test]
+    fn test_insert_single_leaf() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+        let commitment = [1u8; 32];
+
+        let index = tree.insert(commitment, test_hasher);
+
+        assert_eq!(index, 0);
+        assert_eq!(tree.len(), 1);
+        assert!(!tree.is_empty());
+    }
+
+    #[test]
+    fn test_insert_multiple_leaves() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+
+        for i in 0..5 {
+            let commitment = [i as u8; 32];
+            let index = tree.insert(commitment, test_hasher);
+            assert_eq!(index, i as usize);
+        }
+
+        assert_eq!(tree.len(), 5);
+    }
+
+    #[test]
+    fn test_root_changes_on_insert() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+        let initial_root = tree.root();
+
+        tree.insert([1u8; 32], test_hasher);
+        let root_after_insert = tree.root();
+
+        assert_ne!(initial_root, root_after_insert);
+    }
+
+    #[test]
+    fn test_generate_proof() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+
+        // insert some commitments
+        tree.insert([1u8; 32], test_hasher);
+        tree.insert([2u8; 32], test_hasher);
+        tree.insert([3u8; 32], test_hasher);
+
+        // generate proof for leaf 1
+        let proof = tree.generate_proof(1, test_hasher).unwrap();
+
+        assert_eq!(proof.leaf_index, 1);
+        assert_eq!(proof.leaf_value, [2u8; 32]);
+        assert_eq!(proof.path.len(), 4); // depth = 4
+    }
+
+    #[test]
+    fn test_verify_proof() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+
+        tree.insert([1u8; 32], test_hasher);
+        tree.insert([2u8; 32], test_hasher);
+        tree.insert([3u8; 32], test_hasher);
+
+        let proof = tree.generate_proof(1, test_hasher).unwrap();
+
+        // proof should verify against tree root
+        assert!(tree.verify_proof(&proof, test_hasher));
+        assert!(proof.verify(&tree.root(), test_hasher));
+    }
+
+    #[test]
+    fn test_proof_fails_with_wrong_root() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+
+        tree.insert([1u8; 32], test_hasher);
+        let proof = tree.generate_proof(0, test_hasher).unwrap();
+
+        // modify tree
+        tree.insert([2u8; 32], test_hasher);
+
+        // old proof should fail with new root
+        assert!(!tree.verify_proof(&proof, test_hasher));
+    }
+
+    #[test]
+    fn test_proof_compute_root() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+
+        tree.insert([1u8; 32], test_hasher);
+        tree.insert([2u8; 32], test_hasher);
+
+        let proof = tree.generate_proof(0, test_hasher).unwrap();
+        let computed_root = proof.compute_root(test_hasher);
+
+        assert_eq!(computed_root, tree.root());
+    }
+
+    #[test]
+    fn test_proof_out_of_bounds() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+        tree.insert([1u8; 32], test_hasher);
+
+        let result = tree.generate_proof(5, test_hasher);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multiple_proofs_same_tree() {
+        let mut tree = SparseMerkleTree::new(4, test_hasher);
+
+        for i in 0..4 {
+            tree.insert([i as u8; 32], test_hasher);
+        }
+
+        // all proofs should verify
+        for i in 0..4 {
+            let proof = tree.generate_proof(i, test_hasher).unwrap();
+            assert!(tree.verify_proof(&proof, test_hasher));
+        }
+    }
+}

--- a/clvm_zk_core/src/merkle.rs
+++ b/clvm_zk_core/src/merkle.rs
@@ -82,7 +82,11 @@ impl SparseMerkleTree {
     }
 
     /// generate authentication path (merkle proof) for a leaf
-    pub fn generate_proof(&self, leaf_index: usize, hasher: fn(&[u8]) -> [u8; 32]) -> Result<MerkleProof, &'static str> {
+    pub fn generate_proof(
+        &self,
+        leaf_index: usize,
+        hasher: fn(&[u8]) -> [u8; 32],
+    ) -> Result<MerkleProof, &'static str> {
         if leaf_index >= self.leaves.len() {
             return Err("leaf index out of bounds");
         }
@@ -120,7 +124,12 @@ impl SparseMerkleTree {
     }
 
     /// compute hash of a node at given index and level
-    fn compute_node_hash(&self, index: usize, level: usize, hasher: fn(&[u8]) -> [u8; 32]) -> [u8; 32] {
+    fn compute_node_hash(
+        &self,
+        index: usize,
+        level: usize,
+        hasher: fn(&[u8]) -> [u8; 32],
+    ) -> [u8; 32] {
         if level == 0 {
             // base case: leaf level
             if index < self.leaves.len() {

--- a/clvm_zk_core/src/types.rs
+++ b/clvm_zk_core/src/types.rs
@@ -109,8 +109,37 @@ pub struct Input {
     pub chialisp_source: String,
     /// Parameter values for the program - supports both integers and bytes
     pub program_parameters: Vec<ProgramParameter>,
-    /// Optional spend secret for nullifier generation
+    /// Optional spend secret for nullifier generation (OLD PROTOCOL)
     pub spend_secret: Option<[u8; 32]>,
+
+    // ============================================================================
+    // Serial Commitment Protocol (v2.0) Fields
+    // ============================================================================
+
+    /// Serial number randomness for commitment opening
+    /// Used to prove: serial_commitment = hash(serial_number || serial_randomness)
+    pub serial_randomness: Option<[u8; 32]>,
+
+    /// Merkle authentication path for coin membership proof
+    /// Each element is a sibling hash in the path from leaf to root
+    pub merkle_path: Option<Vec<[u8; 32]>>,
+
+    /// Coin commitment value (hash of coin data including serial_commitment)
+    /// This is the leaf value in the merkle tree
+    pub coin_commitment: Option<[u8; 32]>,
+
+    /// Expected serial commitment from the coin
+    /// Guest will verify: hash(nullifier || serial_randomness) == serial_commitment
+    pub serial_commitment: Option<[u8; 32]>,
+
+    /// Expected merkle root (current tree state)
+    /// Guest will verify: computed_root == merkle_root
+    /// This binds the proof to a specific ledger state, preventing replay attacks
+    pub merkle_root: Option<[u8; 32]>,
+
+    /// Puzzle hash for nullifier binding
+    /// Used in old protocol: hash(spend_secret || puzzle_hash)
+    pub puzzle_hash: Option<[u8; 32]>,
 }
 
 #[derive(

--- a/clvm_zk_core/src/types.rs
+++ b/clvm_zk_core/src/types.rs
@@ -115,7 +115,6 @@ pub struct Input {
     // ============================================================================
     // Serial Commitment Protocol (v2.0) Fields
     // ============================================================================
-
     /// Serial number randomness for commitment opening
     /// Used to prove: serial_commitment = hash(serial_number || serial_randomness)
     pub serial_randomness: Option<[u8; 32]>,

--- a/clvm_zk_core/src/types.rs
+++ b/clvm_zk_core/src/types.rs
@@ -102,26 +102,25 @@ pub struct ZKClvmResult {
     pub proof_bytes: Vec<u8>,
 }
 
-/// guest program input/output types
+/// Unified guest program input type
+/// Supports both simple program execution and serial commitment protocol
 #[derive(Serialize, Deserialize, Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Input {
     /// Raw Chialisp source code (e.g., "(mod (x y) (+ x y))")
     pub chialisp_source: String,
     /// Parameter values for the program - supports both integers and bytes
     pub program_parameters: Vec<ProgramParameter>,
+
+    /// Optional serial commitment data for nullifier-based spending
+    /// - None: Simple program execution (BLS tests, basic proving)
+    /// - Some(...): Full serial commitment protocol (blockchain simulator, real spending)
+    pub serial_commitment_data: Option<SerialCommitmentData>,
 }
 
-/// guest program input/output types
+/// Serial commitment protocol data for nullifier-based spending
+/// When None, guest performs simple program execution without nullifier verification
 #[derive(Serialize, Deserialize, Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
-pub struct InputWithSerial {
-    /// Raw Chialisp source code (e.g., "(mod (x y) (+ x y))")
-    pub chialisp_source: String,
-    /// Parameter values for the program - supports both integers and bytes
-    pub program_parameters: Vec<ProgramParameter>,
-
-    // ============================================================================
-    // Serial Commitment Protocol (v2.0) Fields
-    // ============================================================================
+pub struct SerialCommitmentData {
     /// Serial number (becomes the nullifier when revealed)
     /// This is the unique identifier for the coin being spent
     pub serial_number: [u8; 32],
@@ -139,7 +138,7 @@ pub struct InputWithSerial {
     pub coin_commitment: [u8; 32],
 
     /// Expected serial commitment from the coin
-    /// Guest will verify: hash(nullifier || serial_randomness) == serial_commitment
+    /// Guest will verify: hash(serial_number || serial_randomness) == serial_commitment
     pub serial_commitment: [u8; 32],
 
     /// Expected merkle root (current tree state)
@@ -153,6 +152,7 @@ pub struct InputWithSerial {
     /// Puzzle hash that locks the coin (must match program_hash)
     pub program_hash: [u8; 32],
 
+    /// Coin amount
     pub amount: u64,
 }
 

--- a/clvm_zk_core/src/types.rs
+++ b/clvm_zk_core/src/types.rs
@@ -136,6 +136,9 @@ pub struct Input {
     /// This binds the proof to a specific ledger state, preventing replay attacks
     pub merkle_root: Option<[u8; 32]>,
 
+    /// Leaf index in the merkle tree (for position-based hashing)
+    pub leaf_index: Option<usize>,
+
     /// Puzzle hash for nullifier binding
     /// Used in old protocol: hash(spend_secret || puzzle_hash)
     pub puzzle_hash: Option<[u8; 32]>,

--- a/clvm_zk_core/src/types.rs
+++ b/clvm_zk_core/src/types.rs
@@ -109,12 +109,14 @@ pub struct Input {
     pub chialisp_source: String,
     /// Parameter values for the program - supports both integers and bytes
     pub program_parameters: Vec<ProgramParameter>,
-    /// Optional spend secret for nullifier generation (OLD PROTOCOL)
-    pub spend_secret: Option<[u8; 32]>,
 
     // ============================================================================
     // Serial Commitment Protocol (v2.0) Fields
     // ============================================================================
+    /// Serial number (becomes the nullifier when revealed)
+    /// This is the unique identifier for the coin being spent
+    pub serial_number: Option<[u8; 32]>,
+
     /// Serial number randomness for commitment opening
     /// Used to prove: serial_commitment = hash(serial_number || serial_randomness)
     pub serial_randomness: Option<[u8; 32]>,
@@ -139,8 +141,7 @@ pub struct Input {
     /// Leaf index in the merkle tree (for position-based hashing)
     pub leaf_index: Option<usize>,
 
-    /// Puzzle hash for nullifier binding
-    /// Used in old protocol: hash(spend_secret || puzzle_hash)
+    /// Puzzle hash that locks the coin (must match program_hash)
     pub puzzle_hash: Option<[u8; 32]>,
 }
 

--- a/clvm_zk_core/src/types.rs
+++ b/clvm_zk_core/src/types.rs
@@ -109,40 +109,51 @@ pub struct Input {
     pub chialisp_source: String,
     /// Parameter values for the program - supports both integers and bytes
     pub program_parameters: Vec<ProgramParameter>,
+}
+
+/// guest program input/output types
+#[derive(Serialize, Deserialize, Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
+pub struct InputWithSerial {
+    /// Raw Chialisp source code (e.g., "(mod (x y) (+ x y))")
+    pub chialisp_source: String,
+    /// Parameter values for the program - supports both integers and bytes
+    pub program_parameters: Vec<ProgramParameter>,
 
     // ============================================================================
     // Serial Commitment Protocol (v2.0) Fields
     // ============================================================================
     /// Serial number (becomes the nullifier when revealed)
     /// This is the unique identifier for the coin being spent
-    pub serial_number: Option<[u8; 32]>,
+    pub serial_number: [u8; 32],
 
     /// Serial number randomness for commitment opening
     /// Used to prove: serial_commitment = hash(serial_number || serial_randomness)
-    pub serial_randomness: Option<[u8; 32]>,
+    pub serial_randomness: [u8; 32],
 
     /// Merkle authentication path for coin membership proof
     /// Each element is a sibling hash in the path from leaf to root
-    pub merkle_path: Option<Vec<[u8; 32]>>,
+    pub merkle_path: Vec<[u8; 32]>,
 
     /// Coin commitment value (hash of coin data including serial_commitment)
     /// This is the leaf value in the merkle tree
-    pub coin_commitment: Option<[u8; 32]>,
+    pub coin_commitment: [u8; 32],
 
     /// Expected serial commitment from the coin
     /// Guest will verify: hash(nullifier || serial_randomness) == serial_commitment
-    pub serial_commitment: Option<[u8; 32]>,
+    pub serial_commitment: [u8; 32],
 
     /// Expected merkle root (current tree state)
     /// Guest will verify: computed_root == merkle_root
     /// This binds the proof to a specific ledger state, preventing replay attacks
-    pub merkle_root: Option<[u8; 32]>,
+    pub merkle_root: [u8; 32],
 
     /// Leaf index in the merkle tree (for position-based hashing)
-    pub leaf_index: Option<usize>,
+    pub leaf_index: usize,
 
     /// Puzzle hash that locks the coin (must match program_hash)
-    pub puzzle_hash: Option<[u8; 32]>,
+    pub program_hash: [u8; 32],
+
+    pub amount: u64,
 }
 
 #[derive(

--- a/sim_demo.sh
+++ b/sim_demo.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# test script for encrypted payment notes feature
+
+set -e
+
+echo "🧪 testing encrypted payment notes with simulator"
+echo "=================================================="
+
+# clean slate
+echo ""
+echo "1️⃣  initializing simulator..."
+cargo run --no-default-features --features "mock,testing" -- sim init --reset
+
+# create wallets
+echo ""
+echo "2️⃣  creating wallets (alice and bob)..."
+cargo run --no-default-features --features "mock,testing" -- sim wallet alice create
+cargo run --no-default-features --features "mock,testing" -- sim wallet bob create
+
+# fund alice
+echo ""
+echo "3️⃣  funding alice with 3000 mojos..."
+cargo run --no-default-features --features "mock,testing" -- sim faucet alice --amount 1000 --count 1
+cargo run --no-default-features --features "mock,testing" -- sim faucet alice --amount 2000 --count 1
+
+# check alice balance
+echo ""
+echo "4️⃣  alice's initial balance:"
+cargo run --no-default-features --features "mock,testing" -- sim wallet alice balance
+
+# alice sends to bob
+echo ""
+echo "5️⃣  alice sends 500 mojos to bob..."
+cargo run --no-default-features --features "mock,testing" -- sim send alice bob 500 --coins auto
+
+# bob's balance before scan (should be 0)
+echo ""
+echo "6️⃣  bob's balance BEFORE scanning (should be 0):"
+cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+
+# bob scans for encrypted notes
+echo ""
+echo "7️⃣  bob scans for encrypted payment notes..."
+cargo run --no-default-features --features "mock,testing" -- sim scan bob
+
+# bob's balance after scan (should be 500)
+echo ""
+echo "8️⃣  bob's balance AFTER scanning (should be 500):"
+cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+
+# alice sends to bob
+echo ""
+echo "5️⃣  alice sends 500 mojos to bob..."
+cargo run --no-default-features --features "mock,testing" -- sim send alice bob 500 --coins auto
+
+
+# bob's balance before scan (should be 500)
+echo ""
+echo "6️⃣  bob's balance BEFORE scanning (should be 0):"
+cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+
+# bob scans for encrypted notes
+echo ""
+echo "7️⃣  bob scans for encrypted payment notes..."
+cargo run --no-default-features --features "mock,testing" -- sim scan bob
+
+# bob's balance after scan (should be 1000)
+echo ""
+echo "8️⃣  bob's balance AFTER scanning (should be 500):"
+cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+
+
+# bob sends some back to alice
+echo ""
+echo "9️⃣  bob sends 200 mojos back to alice..."
+cargo run --no-default-features --features "mock,testing" -- sim send bob alice 200 --coins auto
+
+# alice scans to receive
+echo ""
+echo "🔟 alice scans for her payment..."
+cargo run --no-default-features --features "mock,testing" -- sim scan alice
+
+# final balances
+echo ""
+echo "✅ final balances:"
+echo ""
+echo "alice:"
+cargo run --no-default-features --features "mock,testing" -- sim wallet alice balance
+echo ""
+echo "bob:"
+cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+
+# show status
+echo ""
+echo "📊 simulator status:"
+cargo run --no-default-features --features "mock,testing" -- sim status
+
+echo ""
+echo "=================================================="
+echo "✅ encrypted payment notes test complete!"
+echo ""
+echo "what happened:"
+echo "  - alice funded with 3000, sent 1000 to bob, received 200 back"
+echo "  - bob received 1000 from alice, sent 200 back"
+echo "  - encrypted notes allow offline receiving"
+echo "  - scan command discovers payments"

--- a/sim_demo.sh
+++ b/sim_demo.sh
@@ -1,106 +1,191 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test script for encrypted payment notes feature
 
 set -e
 
+# timing helpers
+TOTAL_START=$(date +%s)
+TOTAL_SEND_TIME=0
+TOTAL_SCAN_TIME=0
+SEND_COUNT=0
+SCAN_COUNT=0
+
+time_start() {
+    STEP_START=$(date +%s.%N 2>/dev/null || echo "0")
+}
+
+time_end() {
+    local step_type="$1"
+    if [ "$STEP_START" != "0" ]; then
+        local step_end=$(date +%s.%N)
+        local duration=$(echo "$step_end - $STEP_START" | bc 2>/dev/null || echo "0")
+        printf "   ⏱️  %.2fs\n" "$duration"
+        
+        if [[ "$step_type" == "send"* ]]; then
+            TOTAL_SEND_TIME=$(echo "$TOTAL_SEND_TIME + $duration" | bc 2>/dev/null || echo "0")
+            SEND_COUNT=$((SEND_COUNT + 1))
+        elif [[ "$step_type" == "scan"* ]]; then
+            TOTAL_SCAN_TIME=$(echo "$TOTAL_SCAN_TIME + $duration" | bc 2>/dev/null || echo "0")
+            SCAN_COUNT=$((SCAN_COUNT + 1))
+        fi
+    fi
+}
+
+# backend selection (default: risc0)
+BACKEND="${1:-risc0}"
+
+if [[ "$BACKEND" != "risc0" && "$BACKEND" != "sp1" ]]; then
+    echo "❌ invalid backend: $BACKEND"
+    echo "usage: $0 [risc0|sp1]"
+    exit 1
+fi
+
+# backend-specific build directory and binary path
+BUILD_DIR="./target/$BACKEND"
+BINARY="$BUILD_DIR/release/clvm-zk"
+
+# check if binary exists, build if needed
+if [ ! -f "$BINARY" ]; then
+    echo "🔨 binary not found for $BACKEND backend, building..."
+    cargo build --release --target-dir "$BUILD_DIR" --no-default-features --features "$BACKEND,testing"
+    
+    echo "✅ build complete: $BINARY"
+    echo ""
+fi
+
 echo "🧪 testing encrypted payment notes with simulator"
+echo "backend: $BACKEND"
 echo "=================================================="
 
 # clean slate
 echo ""
-echo "1️⃣  initializing simulator..."
-cargo run --no-default-features --features "mock,testing" -- sim init --reset
+echo "🗑️  resetting simulator state..."
+$BINARY sim init --reset
+echo "✅ simulator reset complete"
 
 # create wallets
 echo ""
 echo "2️⃣  creating wallets (alice and bob)..."
-cargo run --no-default-features --features "mock,testing" -- sim wallet alice create
-cargo run --no-default-features --features "mock,testing" -- sim wallet bob create
+$BINARY sim wallet alice create
+$BINARY sim wallet bob create
 
 # fund alice
 echo ""
 echo "3️⃣  funding alice with 3000 mojos..."
-cargo run --no-default-features --features "mock,testing" -- sim faucet alice --amount 1000 --count 1
-cargo run --no-default-features --features "mock,testing" -- sim faucet alice --amount 2000 --count 1
+$BINARY sim faucet alice --amount 1000 --count 1
+$BINARY sim faucet alice --amount 2000 --count 1
 
 # check alice balance
 echo ""
 echo "4️⃣  alice's initial balance:"
-cargo run --no-default-features --features "mock,testing" -- sim wallet alice balance
+$BINARY sim wallet alice balance
 
 # alice sends to bob
 echo ""
 echo "5️⃣  alice sends 500 mojos to bob..."
-cargo run --no-default-features --features "mock,testing" -- sim send alice bob 500 --coins auto
+time_start
+$BINARY sim send alice bob 500 --coins auto
+time_end "send_1"
 
 # bob's balance before scan (should be 0)
 echo ""
 echo "6️⃣  bob's balance BEFORE scanning (should be 0):"
-cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+$BINARY sim wallet bob balance
 
 # bob scans for encrypted notes
 echo ""
 echo "7️⃣  bob scans for encrypted payment notes..."
-cargo run --no-default-features --features "mock,testing" -- sim scan bob
+time_start
+$BINARY sim scan bob
+time_end "scan_1"
 
 # bob's balance after scan (should be 500)
 echo ""
 echo "8️⃣  bob's balance AFTER scanning (should be 500):"
-cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+$BINARY sim wallet bob balance
 
-# alice sends to bob
+# alice sends to bob again
 echo ""
-echo "5️⃣  alice sends 500 mojos to bob..."
-cargo run --no-default-features --features "mock,testing" -- sim send alice bob 500 --coins auto
-
+echo "5️⃣  alice sends 500 mojos to bob (second payment)..."
+time_start
+$BINARY sim send alice bob 500 --coins auto
+time_end "send_2"
 
 # bob's balance before scan (should be 500)
 echo ""
 echo "6️⃣  bob's balance BEFORE scanning (should be 0):"
-cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+$BINARY sim wallet bob balance
 
-# bob scans for encrypted notes
+# bob scans for encrypted notes again
 echo ""
-echo "7️⃣  bob scans for encrypted payment notes..."
-cargo run --no-default-features --features "mock,testing" -- sim scan bob
+echo "7️⃣  bob scans for encrypted payment notes again..."
+time_start
+$BINARY sim scan bob
+time_end "scan_2"
 
 # bob's balance after scan (should be 1000)
 echo ""
 echo "8️⃣  bob's balance AFTER scanning (should be 500):"
-cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+$BINARY sim wallet bob balance
 
 
 # bob sends some back to alice
 echo ""
 echo "9️⃣  bob sends 200 mojos back to alice..."
-cargo run --no-default-features --features "mock,testing" -- sim send bob alice 200 --coins auto
+time_start
+$BINARY sim send bob alice 200 --coins auto
+time_end "send_3"
 
 # alice scans to receive
 echo ""
 echo "🔟 alice scans for her payment..."
-cargo run --no-default-features --features "mock,testing" -- sim scan alice
+time_start
+$BINARY sim scan alice
+time_end "scan_3"
 
 # final balances
 echo ""
 echo "✅ final balances:"
 echo ""
 echo "alice:"
-cargo run --no-default-features --features "mock,testing" -- sim wallet alice balance
+$BINARY sim wallet alice balance
 echo ""
 echo "bob:"
-cargo run --no-default-features --features "mock,testing" -- sim wallet bob balance
+$BINARY sim wallet bob balance
 
 # show status
 echo ""
 echo "📊 simulator status:"
-cargo run --no-default-features --features "mock,testing" -- sim status
+$BINARY sim status
+
+# show saved proofs
+echo ""
+echo "🔐 saved proofs:"
+$BINARY sim proofs
+
+TOTAL_END=$(date +%s)
+TOTAL_DURATION=$((TOTAL_END - TOTAL_START))
 
 echo ""
 echo "=================================================="
 echo "✅ encrypted payment notes test complete!"
+echo ""
+echo "backend used: $BACKEND"
+echo ""
+echo "⏱️  timing summary:"
+if [ "$SEND_COUNT" -gt 0 ] && [ "$TOTAL_SEND_TIME" != "0" ]; then
+    AVG_SEND=$(echo "scale=2; $TOTAL_SEND_TIME / $SEND_COUNT" | bc 2>/dev/null || echo "N/A")
+    printf "  - total send time: %.2fs (%d transactions, avg: %ss)\n" "$TOTAL_SEND_TIME" "$SEND_COUNT" "$AVG_SEND"
+fi
+if [ "$SCAN_COUNT" -gt 0 ] && [ "$TOTAL_SCAN_TIME" != "0" ]; then
+    AVG_SCAN=$(echo "scale=2; $TOTAL_SCAN_TIME / $SCAN_COUNT" | bc 2>/dev/null || echo "N/A")
+    printf "  - total scan time: %.2fs (%d scans, avg: %ss)\n" "$TOTAL_SCAN_TIME" "$SCAN_COUNT" "$AVG_SCAN"
+fi
+echo "  - total runtime: ${TOTAL_DURATION}s"
 echo ""
 echo "what happened:"
 echo "  - alice funded with 3000, sent 1000 to bob, received 200 back"
 echo "  - bob received 1000 from alice, sent 200 back"
 echo "  - encrypted notes allow offline receiving"
 echo "  - scan command discovers payments"
+echo "  - all zk proofs saved to simulator_data/state.json"

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -87,6 +87,7 @@ impl ZKCLVMBackend for Risc0Backend {
             merkle_path: None,
             coin_commitment: None,
             merkle_root: None,
+            leaf_index: None,
             puzzle_hash: None,
         };
         self.prove_with_input(input)
@@ -130,6 +131,7 @@ impl ZKCLVMBackend for Sp1Backend {
             merkle_path: None,
             coin_commitment: None,
             merkle_root: None,
+            leaf_index: None,
             puzzle_hash: None,
         };
         self.prove_with_input(input)
@@ -173,6 +175,7 @@ impl ZKCLVMBackend for MockBackend {
             merkle_path: None,
             coin_commitment: None,
             merkle_root: None,
+            leaf_index: None,
             puzzle_hash: None,
         };
         self.prove_with_input(input)

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -78,7 +78,18 @@ impl ZKCLVMBackend for Risc0Backend {
         program_parameters: &[ProgramParameter],
         spend_secret: [u8; 32],
     ) -> Result<ZKClvmResult, ClvmZkError> {
-        self.prove_chialisp_with_nullifier(chialisp_source, program_parameters, spend_secret)
+        let input = clvm_zk_core::Input {
+            chialisp_source: chialisp_source.to_string(),
+            program_parameters: program_parameters.to_vec(),
+            spend_secret: Some(spend_secret),
+            serial_randomness: None,
+            serial_commitment: None,
+            merkle_path: None,
+            coin_commitment: None,
+            merkle_root: None,
+            puzzle_hash: None,
+        };
+        self.prove_with_input(input)
     }
 
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError> {
@@ -110,7 +121,18 @@ impl ZKCLVMBackend for Sp1Backend {
         program_parameters: &[ProgramParameter],
         spend_secret: [u8; 32],
     ) -> Result<ZKClvmResult, ClvmZkError> {
-        self.prove_chialisp_with_nullifier(chialisp_source, program_parameters, spend_secret)
+        let input = clvm_zk_core::Input {
+            chialisp_source: chialisp_source.to_string(),
+            program_parameters: program_parameters.to_vec(),
+            spend_secret: Some(spend_secret),
+            serial_randomness: None,
+            serial_commitment: None,
+            merkle_path: None,
+            coin_commitment: None,
+            merkle_root: None,
+            puzzle_hash: None,
+        };
+        self.prove_with_input(input)
     }
 
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError> {
@@ -142,7 +164,18 @@ impl ZKCLVMBackend for MockBackend {
         program_parameters: &[ProgramParameter],
         spend_secret: [u8; 32],
     ) -> Result<ZKClvmResult, ClvmZkError> {
-        self.prove_chialisp_with_nullifier(chialisp_source, program_parameters, spend_secret)
+        let input = clvm_zk_core::Input {
+            chialisp_source: chialisp_source.to_string(),
+            program_parameters: program_parameters.to_vec(),
+            spend_secret: Some(spend_secret),
+            serial_randomness: None,
+            serial_commitment: None,
+            merkle_path: None,
+            coin_commitment: None,
+            merkle_root: None,
+            puzzle_hash: None,
+        };
+        self.prove_with_input(input)
     }
 
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError> {

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -9,13 +9,6 @@ pub trait ZKCLVMBackend {
         program_parameters: &[ProgramParameter],
     ) -> Result<ZKClvmResult, ClvmZkError>;
 
-    fn prove_with_nullifier(
-        &self,
-        chialisp_source: &str,
-        program_parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
-    ) -> Result<ZKClvmResult, ClvmZkError>;
-
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError>;
 
     fn backend_name(&self) -> &'static str;
@@ -72,27 +65,6 @@ impl ZKCLVMBackend for Risc0Backend {
         self.prove_chialisp_program(chialisp_source, program_parameters)
     }
 
-    fn prove_with_nullifier(
-        &self,
-        chialisp_source: &str,
-        program_parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
-    ) -> Result<ZKClvmResult, ClvmZkError> {
-        let input = clvm_zk_core::Input {
-            chialisp_source: chialisp_source.to_string(),
-            program_parameters: program_parameters.to_vec(),
-            spend_secret: Some(spend_secret),
-            serial_randomness: None,
-            serial_commitment: None,
-            merkle_path: None,
-            coin_commitment: None,
-            merkle_root: None,
-            leaf_index: None,
-            puzzle_hash: None,
-        };
-        self.prove_with_input(input)
-    }
-
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError> {
         self.verify_proof_and_extract(proof)
     }
@@ -116,27 +88,6 @@ impl ZKCLVMBackend for Sp1Backend {
         self.prove_chialisp_program(chialisp_source, program_parameters)
     }
 
-    fn prove_with_nullifier(
-        &self,
-        chialisp_source: &str,
-        program_parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
-    ) -> Result<ZKClvmResult, ClvmZkError> {
-        let input = clvm_zk_core::Input {
-            chialisp_source: chialisp_source.to_string(),
-            program_parameters: program_parameters.to_vec(),
-            spend_secret: Some(spend_secret),
-            serial_randomness: None,
-            serial_commitment: None,
-            merkle_path: None,
-            coin_commitment: None,
-            merkle_root: None,
-            leaf_index: None,
-            puzzle_hash: None,
-        };
-        self.prove_with_input(input)
-    }
-
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError> {
         self.verify_proof_and_extract(proof)
     }
@@ -158,27 +109,6 @@ impl ZKCLVMBackend for MockBackend {
         program_parameters: &[ProgramParameter],
     ) -> Result<ZKClvmResult, ClvmZkError> {
         self.prove_chialisp_program(chialisp_source, program_parameters)
-    }
-
-    fn prove_with_nullifier(
-        &self,
-        chialisp_source: &str,
-        program_parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
-    ) -> Result<ZKClvmResult, ClvmZkError> {
-        let input = clvm_zk_core::Input {
-            chialisp_source: chialisp_source.to_string(),
-            program_parameters: program_parameters.to_vec(),
-            spend_secret: Some(spend_secret),
-            serial_randomness: None,
-            serial_commitment: None,
-            merkle_path: None,
-            coin_commitment: None,
-            merkle_root: None,
-            leaf_index: None,
-            puzzle_hash: None,
-        };
-        self.prove_with_input(input)
     }
 
     fn verify_proof(&self, proof: &[u8]) -> Result<(bool, [u8; 32], Vec<u8>), ClvmZkError> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -750,9 +750,9 @@ impl WalletCoinWrapper {
         self.wallet_coin.amount()
     }
 
-    /// get coin nullifier
-    fn nullifier(&self) -> [u8; 32] {
-        self.wallet_coin.nullifier()
+    /// get coin serial_number
+    fn serial_number(&self) -> [u8; 32] {
+        self.wallet_coin.serial_number()
     }
 
     /// get coin puzzle hash
@@ -1125,13 +1125,13 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
             println!("coins in wallet '{}':", name);
             for (i, coin) in wallet.coins.iter().enumerate() {
                 let status = if coin.spent { "spent" } else { "unspent" };
-                let nullifier = coin.nullifier();
+                let serial_number = coin.serial_number();
                 println!(
-                    "  {}. {} {} (nullifier: {}...)",
+                    "  {}. {} {} (serial: {}...)",
                     i,
                     coin.amount(),
                     status,
-                    hex::encode(&nullifier[0..8])
+                    hex::encode(&serial_number[0..8])
                 );
             }
         }
@@ -1159,12 +1159,12 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
             );
             let mut total = 0u64;
             for (i, coin) in &unspent_coins {
-                let nullifier = coin.nullifier();
+                let serial_number = coin.serial_number();
                 println!(
-                    "  [{}] {} (nullifier: {}...)",
+                    "  [{}] {} (serial: {}...)",
                     i,
                     coin.amount(),
-                    hex::encode(&nullifier[0..8])
+                    hex::encode(&serial_number[0..8])
                 );
                 total += coin.amount();
             }
@@ -1578,7 +1578,7 @@ fn scan_command(data_dir: &PathBuf, wallet_name: &str) -> Result<(), ClvmZkError
 
             // Check if we already have this coin
             let nullifier = payment_note.serial_number;
-            let already_have = wallet.coins.iter().any(|c| c.nullifier() == nullifier);
+            let already_have = wallet.coins.iter().any(|c| c.serial_number() == nullifier);
 
             if already_have {
                 println!("    (already in wallet, skipping)");
@@ -1726,11 +1726,11 @@ fn spend_to_puzzle_command(
             // mark coins as spent
             let from_wallet = state.wallets.get_mut(from).unwrap();
             for coin in &spend_coins {
-                let coin_nullifier = coin.nullifier();
+                let coin_serial = coin.serial_number();
                 if let Some(wallet_coin) = from_wallet
                     .coins
                     .iter_mut()
-                    .find(|c| c.nullifier() == coin_nullifier)
+                    .find(|c| c.serial_number() == coin_serial)
                 {
                     wallet_coin.spent = true;
                 }
@@ -1797,9 +1797,9 @@ fn spend_to_puzzle_command(
 
             state.save(data_dir)?;
             println!(
-                "locked {} in puzzle coin (nullifier: {}..., program: {})",
+                "locked {} in puzzle coin (serial: {}..., program: {})",
                 amount,
-                hex::encode(&puzzle_coin.secrets.nullifier()[0..8]),
+                hex::encode(&puzzle_coin.secrets.serial_number()[0..8]),
                 program
             );
         }
@@ -1885,8 +1885,8 @@ fn spend_to_wallet_command(
 
             // remove the spent puzzle coin
             let puzzle_coins = state.puzzle_coins.as_mut().unwrap();
-            let spent_nullifier = puzzle_coin.secrets.nullifier();
-            puzzle_coins.retain(|c| c.secrets.nullifier() != spent_nullifier);
+            let spent_serial = puzzle_coin.secrets.serial_number();
+            puzzle_coins.retain(|c| c.secrets.serial_number() != spent_serial);
 
             // create new coin for destination wallet
             let to_wallet = state.wallets.get_mut(to).unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -712,18 +712,46 @@ struct WalletData {
     network: Network,
     account_index: u32,
     next_coin_index: u32, // Track next coin index for HD derivation
-    coins: Vec<WalletCoin>,
+    coins: Vec<WalletCoinWrapper>,
 }
 
+/// wrapper around WalletPrivateCoin with additional CLI-specific state
 #[derive(Serialize, Deserialize, Clone)]
-struct WalletCoin {
-    spend_secret: [u8; 32],
-    puzzle_hash: [u8; 32],
-    amount: u64,
-    nullifier: [u8; 32],
+struct WalletCoinWrapper {
+    /// the actual wallet coin with secrets
+    wallet_coin: crate::wallet::WalletPrivateCoin,
+    /// the chialisp program for this coin
     program: String,
-    coin_index: u32, // HD derivation index
+    /// whether this coin has been spent
     spent: bool,
+}
+
+impl WalletCoinWrapper {
+    /// get coin amount
+    fn amount(&self) -> u64 {
+        self.wallet_coin.amount()
+    }
+
+    /// get coin nullifier
+    fn nullifier(&self) -> [u8; 32] {
+        self.wallet_coin.nullifier()
+    }
+
+    /// get coin puzzle hash
+    #[allow(dead_code)]
+    fn puzzle_hash(&self) -> [u8; 32] {
+        self.wallet_coin.puzzle_hash()
+    }
+
+    /// convert to PrivateCoin for spending
+    fn to_private_coin(&self) -> PrivateCoin {
+        self.wallet_coin.to_protocol_coin()
+    }
+
+    /// get coin secrets (needed for spending with serial commitment)
+    fn secrets(&self) -> &clvm_zk_core::coin_commitment::CoinSecrets {
+        &self.wallet_coin.secrets
+    }
 }
 
 impl WalletData {
@@ -745,23 +773,19 @@ impl WalletData {
         puzzle_hash: [u8; 32],
         amount: u64,
         program: String,
-    ) -> Result<WalletCoin, WalletError> {
-        let hd_wallet = self.get_hd_wallet()?;
+    ) -> Result<WalletCoinWrapper, WalletError> {
         let coin_index = self.next_coin_index();
 
-        // Derive spend secret using HD wallet
-        let spend_secret_data = hd_wallet.derive_spend_secret(self.account_index, coin_index)?;
-
-        // Create nullifier using HD wallet (need puzzle hash)
-        let nullifier = hd_wallet.create_nullifier(self.account_index, coin_index, puzzle_hash)?;
-
-        Ok(WalletCoin {
-            spend_secret: spend_secret_data.secret,
+        let wallet_coin = crate::wallet::WalletPrivateCoin::new(
             puzzle_hash,
             amount,
-            nullifier: nullifier.bytes,
-            program,
+            self.account_index,
             coin_index,
+        );
+
+        Ok(WalletCoinWrapper {
+            wallet_coin,
+            program,
             spent: false,
         })
     }
@@ -769,11 +793,10 @@ impl WalletData {
 
 #[derive(Serialize, Deserialize, Clone)]
 struct PuzzleCoin {
-    spend_secret: [u8; 32],
     puzzle_hash: [u8; 32],
     amount: u64,
     program: String,
-    nullifier: [u8; 32],
+    secrets: clvm_zk_core::coin_commitment::CoinSecrets,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -796,8 +819,8 @@ struct DiscoveredCoin {
 fn parse_coin_indices(
     coin_indices: &str,
     wallet: &WalletData,
-) -> Result<Vec<WalletCoin>, ClvmZkError> {
-    let unspent_coins: Vec<&WalletCoin> = wallet.coins.iter().filter(|c| !c.spent).collect();
+) -> Result<Vec<WalletCoinWrapper>, ClvmZkError> {
+    let unspent_coins: Vec<&WalletCoinWrapper> = wallet.coins.iter().filter(|c| !c.spent).collect();
 
     if coin_indices == "all" {
         return Ok(unspent_coins.into_iter().cloned().collect());
@@ -1021,7 +1044,7 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
                 .coins
                 .iter()
                 .filter(|c| !c.spent)
-                .map(|c| c.amount)
+                .map(|c| c.amount())
                 .sum();
 
             let unspent_count = wallet.coins.iter().filter(|c| !c.spent).count();
@@ -1044,12 +1067,13 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
             println!("coins in wallet '{}':", name);
             for (i, coin) in wallet.coins.iter().enumerate() {
                 let status = if coin.spent { "spent" } else { "unspent" };
+                let nullifier = coin.nullifier();
                 println!(
                     "  {}. {} {} (nullifier: {}...)",
                     i,
-                    coin.amount,
+                    coin.amount(),
                     status,
-                    hex::encode(&coin.nullifier[0..8])
+                    hex::encode(&nullifier[0..8])
                 );
             }
         }
@@ -1059,7 +1083,7 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
                 ClvmZkError::InvalidProgram(format!("wallet '{}' not found", name))
             })?;
 
-            let unspent_coins: Vec<(usize, &WalletCoin)> = wallet
+            let unspent_coins: Vec<(usize, &WalletCoinWrapper)> = wallet
                 .coins
                 .iter()
                 .enumerate()
@@ -1077,13 +1101,14 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
             );
             let mut total = 0u64;
             for (i, coin) in &unspent_coins {
+                let nullifier = coin.nullifier();
                 println!(
                     "  [{}] {} (nullifier: {}...)",
                     i,
-                    coin.amount,
-                    hex::encode(&coin.nullifier[0..8])
+                    coin.amount(),
+                    hex::encode(&nullifier[0..8])
                 );
-                total += coin.amount;
+                total += coin.amount();
             }
 
             println!("total unspent: {}", total);
@@ -1098,7 +1123,7 @@ fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Resul
                 .coins
                 .iter()
                 .filter(|c| !c.spent)
-                .map(|c| c.amount)
+                .map(|c| c.amount())
                 .sum();
 
             let unspent_count = wallet.coins.iter().filter(|c| !c.spent).count();
@@ -1183,7 +1208,7 @@ fn wallets_command(data_dir: &Path) -> Result<(), ClvmZkError> {
             .coins
             .iter()
             .filter(|c| !c.spent)
-            .map(|c| c.amount)
+            .map(|c| c.amount())
             .sum();
 
         let unspent = wallet.coins.iter().filter(|c| !c.spent).count();
@@ -1249,13 +1274,13 @@ fn send_command(
         let mut selected_amount = 0u64;
 
         // sort coins by amount (descending) for better selection
-        let mut coin_choices: Vec<(usize, &WalletCoin)> = from_wallet
+        let mut coin_choices: Vec<(usize, &WalletCoinWrapper)> = from_wallet
             .coins
             .iter()
             .enumerate()
             .filter(|(_, coin)| !coin.spent)
             .collect();
-        coin_choices.sort_by(|a, b| b.1.amount.cmp(&a.1.amount));
+        coin_choices.sort_by(|a, b| b.1.amount().cmp(&a.1.amount()));
 
         // greedily select coins until we have enough
         for (index, coin) in coin_choices {
@@ -1263,7 +1288,7 @@ fn send_command(
                 break;
             }
             selected_indices.push(index);
-            selected_amount += coin.amount;
+            selected_amount += coin.amount();
         }
 
         if selected_amount < amount {
@@ -1309,9 +1334,11 @@ fn send_command(
             )));
         }
 
-        let private_coin = PrivateCoin::new(coin.spend_secret, coin.puzzle_hash, coin.amount);
-        coins_to_spend.push((private_coin, coin.program.clone()));
-        total_input += coin.amount;
+        // convert wallet coin to protocol coin for spending, keeping secrets
+        let private_coin = coin.to_private_coin();
+        let secrets = coin.secrets().clone();
+        coins_to_spend.push((private_coin, coin.program.clone(), secrets));
+        total_input += coin.amount();
     }
 
     // validate sufficient balance
@@ -1333,9 +1360,10 @@ fn send_command(
     let mut sim = CLVMZkSimulator::new();
 
     // add coins to simulator UTXO set
-    for (coin, _program) in &coins_to_spend {
+    for (coin, _program, secrets) in &coins_to_spend {
         sim.add_coin(
             coin.clone(),
+            secrets,
             CoinMetadata {
                 owner: from.to_string(),
                 coin_type: CoinType::Regular,
@@ -1344,7 +1372,7 @@ fn send_command(
         );
     }
 
-    // attempt to spend coins using simulator
+    // spend coins using serial commitment protocol (v2.0)
     let tx_result = sim.spend_coins(coins_to_spend);
 
     match tx_result {
@@ -1408,13 +1436,6 @@ fn send_command(
     Ok(())
 }
 
-// Simple spend secret derivation for non-wallet puzzle coins
-fn derive_puzzle_spend_secret(index: u64) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(b"puzzle_spend_secret_derivation_v1");
-    hasher.update(index.to_le_bytes());
-    hasher.finalize().into()
-}
 
 // ============================================================================
 // General Purpose Puzzle Commands
@@ -1443,7 +1464,7 @@ fn spend_to_puzzle_command(
     // get spendable coins from source wallet
     let spend_coins = parse_coin_indices(coins, &state.wallets[from])?;
 
-    let total_input: u64 = spend_coins.iter().map(|c| c.amount).sum();
+    let total_input: u64 = spend_coins.iter().map(|c| c.amount()).sum();
     if total_input < amount {
         return Err(ClvmZkError::ProofGenerationFailed(format!(
             "insufficient funds: need {}, have {}",
@@ -1457,8 +1478,10 @@ fn spend_to_puzzle_command(
         spend_coins
             .iter()
             .map(|wc| {
-                let coin = PrivateCoin::new(wc.spend_secret, wc.puzzle_hash, wc.amount);
-                (coin, wc.program.clone())
+                // convert wallet coin to protocol coin for spending
+                let coin = wc.to_private_coin();
+                let secrets = wc.secrets().clone();
+                (coin, wc.program.clone(), secrets)
             })
             .collect(),
     ) {
@@ -1466,25 +1489,24 @@ fn spend_to_puzzle_command(
             // mark coins as spent
             let from_wallet = state.wallets.get_mut(from).unwrap();
             for coin in &spend_coins {
+                let coin_nullifier = coin.nullifier();
                 if let Some(wallet_coin) = from_wallet
                     .coins
                     .iter_mut()
-                    .find(|c| c.nullifier == coin.nullifier)
+                    .find(|c| c.nullifier() == coin_nullifier)
                 {
                     wallet_coin.spent = true;
                 }
             }
 
-            // create new puzzle coin
-            let spend_secret = derive_puzzle_spend_secret(state.faucet_nonce);
-            state.faucet_nonce += 1;
+            // create new puzzle coin with proper CoinSecrets
+            let (_coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, amount);
 
             let puzzle_coin = PuzzleCoin {
-                spend_secret,
                 puzzle_hash,
                 amount,
                 program: program.to_string(),
-                nullifier: PrivateCoin::new(spend_secret, puzzle_hash, amount).nullifier(),
+                secrets,
             };
 
             // store puzzle coin in simulator state
@@ -1516,7 +1538,7 @@ fn spend_to_puzzle_command(
             println!(
                 "locked {} in puzzle coin (nullifier: {}..., program: {})",
                 amount,
-                hex::encode(&puzzle_coin.nullifier[0..8]),
+                hex::encode(&puzzle_coin.secrets.nullifier()[0..8]),
                 program
             );
         }
@@ -1576,17 +1598,19 @@ fn spend_to_wallet_command(
 
     // create simulator and spend the puzzle coin
     let mut sim = CLVMZkSimulator::new();
+    // reconstruct PrivateCoin from puzzle_coin data
     let coin = PrivateCoin::new(
-        puzzle_coin.spend_secret,
         puzzle_coin.puzzle_hash,
         puzzle_coin.amount,
+        puzzle_coin.secrets.serial_commitment(crate::crypto_utils::hash_data_default),
     );
 
-    match sim.spend_coins(vec![(coin, puzzle_coin.program.clone())]) {
+    match sim.spend_coins(vec![(coin, puzzle_coin.program.clone(), puzzle_coin.secrets.clone())]) {
         Ok(_tx) => {
             // remove the spent puzzle coin
             let puzzle_coins = state.puzzle_coins.as_mut().unwrap();
-            puzzle_coins.retain(|c| c.nullifier != puzzle_coin.nullifier);
+            let spent_nullifier = puzzle_coin.secrets.nullifier();
+            puzzle_coins.retain(|c| c.secrets.nullifier() != spent_nullifier);
 
             // create new coin for destination wallet
             let to_wallet = state.wallets.get_mut(to).unwrap();
@@ -1602,16 +1626,13 @@ fn spend_to_wallet_command(
             let change = puzzle_coin.amount - amount;
             if change > 0 {
                 let change_puzzle_hash = Sha256::digest(puzzle_coin.program.as_bytes()).into();
-                let spend_secret = derive_puzzle_spend_secret(state.faucet_nonce);
-                state.faucet_nonce += 1;
+                let (_coin, secrets) = PrivateCoin::new_with_secrets(change_puzzle_hash, change);
 
                 let change_puzzle_coin = PuzzleCoin {
-                    spend_secret,
                     puzzle_hash: change_puzzle_hash,
                     amount: change,
                     program: puzzle_coin.program.clone(),
-                    nullifier: PrivateCoin::new(spend_secret, change_puzzle_hash, change)
-                        .nullifier(),
+                    secrets,
                 };
 
                 puzzle_coins.push(change_puzzle_coin);
@@ -1637,8 +1658,7 @@ fn spend_to_wallet_command(
 }
 
 fn observer_command(data_dir: &PathBuf, action: ObserverAction) -> Result<(), ClvmZkError> {
-    use crate::wallet::hd_wallet::ViewOnlyWallet;
-    use crate::wallet::{Network, ViewingKey};
+    use crate::wallet::Network;
 
     let mut state = SimulatorState::load(data_dir)?;
 
@@ -1721,51 +1741,11 @@ fn observer_command(data_dir: &PathBuf, action: ObserverAction) -> Result<(), Cl
         }
 
         ObserverAction::Scan { name, max_index } => {
-            let observer = state.observer_wallets.get_mut(&name).ok_or_else(|| {
-                ClvmZkError::InvalidProgram(format!("observer wallet \"{}\" not found", name))
-            })?;
+            let _ = (name, max_index);
 
-            let viewing_key = ViewingKey {
-                key: observer.viewing_key,
-                account_index: observer.account_index,
-                network: observer.network,
-            };
-
-            let view_wallet = ViewOnlyWallet::from_viewing_key(viewing_key);
-            let mut discovered = 0;
-
-            // Simple scanning implementation
-            for coin_index in 0..max_index {
-                let viewing_tag = view_wallet.derive_viewing_tag(coin_index);
-
-                // Check if this viewing tag matches any existing coins
-                for wallet in state.wallets.values() {
-                    for coin in &wallet.coins {
-                        if let Ok(wallet_hd) = wallet.get_hd_wallet() {
-                            if let Ok(account) = wallet_hd.derive_account(wallet.account_index) {
-                                let coin_keys =
-                                    account.derive_coin_keys(coin_index, coin.puzzle_hash);
-                                if coin_keys.viewing_tag == viewing_tag {
-                                    let discovered_coin = DiscoveredCoin {
-                                        coin_index,
-                                        viewing_tag,
-                                        nullifier: Some(coin.nullifier),
-                                    };
-                                    observer.discovered_coins.push(discovered_coin);
-                                    discovered += 1;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            state.save(data_dir)?;
-            println!(
-                "scanned {} coin indices, discovered {} new coins",
-                max_index, discovered
-            );
+            return Err(ClvmZkError::InvalidProgram(
+                "observer scanning not supported - requires coinsecrets backup".to_string()
+            ));
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -897,7 +897,7 @@ impl SimulatorState {
         }
     }
 
-    fn save(&self, data_dir: &PathBuf) -> Result<(), ClvmZkError> {
+    fn save(&self, data_dir: &Path) -> Result<(), ClvmZkError> {
         fs::create_dir_all(data_dir).map_err(|e| {
             ClvmZkError::SerializationError(format!("failed to create data dir: {e}"))
         })?;
@@ -913,7 +913,7 @@ impl SimulatorState {
 }
 
 // Simulator CLI commands
-fn run_simulator_command(data_dir: &PathBuf, action: SimAction) -> Result<(), ClvmZkError> {
+fn run_simulator_command(data_dir: &Path, action: SimAction) -> Result<(), ClvmZkError> {
     match action {
         SimAction::Init { reset } => {
             if reset && data_dir.exists() {
@@ -992,7 +992,7 @@ fn run_simulator_command(data_dir: &PathBuf, action: SimAction) -> Result<(), Cl
 }
 
 fn faucet_command(
-    data_dir: &PathBuf,
+    data_dir: &Path,
     wallet_name: &str,
     amount: u64,
     count: u32,
@@ -1048,7 +1048,7 @@ fn faucet_command(
     Ok(())
 }
 
-fn wallet_command(data_dir: &PathBuf, name: &str, action: WalletAction) -> Result<(), ClvmZkError> {
+fn wallet_command(data_dir: &Path, name: &str, action: WalletAction) -> Result<(), ClvmZkError> {
     let mut state = SimulatorState::load(data_dir)?;
 
     match action {
@@ -1280,9 +1280,10 @@ fn wallets_command(data_dir: &Path) -> Result<(), ClvmZkError> {
 }
 
 // Helper functions
-fn create_faucet_puzzle(amount: u64) -> (String, [u8; 32]) {
-    let program = format!("{}", amount);
-    let hash = Sha256::digest(program.as_bytes()).into();
+fn create_faucet_puzzle(_amount: u64) -> (String, [u8; 32]) {
+    let program = "(mod () 1)".to_string();
+    let hash =
+        compile_chialisp_template_hash_default(&program).expect("faucet puzzle compilation failed");
     (program, hash)
 }
 
@@ -1307,7 +1308,7 @@ fn decode_clvm_output(output_bytes: &[u8]) -> Option<String> {
 }
 
 fn send_command(
-    data_dir: &PathBuf,
+    data_dir: &Path,
     from: &str,
     to: &str,
     amount: u64,
@@ -1545,7 +1546,7 @@ fn send_command(
     Ok(())
 }
 
-fn scan_command(data_dir: &PathBuf, wallet_name: &str) -> Result<(), ClvmZkError> {
+fn scan_command(data_dir: &Path, wallet_name: &str) -> Result<(), ClvmZkError> {
     let mut state = SimulatorState::load(data_dir)?;
 
     // Get wallet
@@ -1640,7 +1641,7 @@ fn scan_command(data_dir: &PathBuf, wallet_name: &str) -> Result<(), ClvmZkError
     Ok(())
 }
 
-fn proofs_command(data_dir: &PathBuf) -> Result<(), ClvmZkError> {
+fn proofs_command(data_dir: &Path) -> Result<(), ClvmZkError> {
     let state = SimulatorState::load(data_dir)?;
 
     if state.spend_bundles.is_empty() {
@@ -1670,7 +1671,7 @@ fn proofs_command(data_dir: &PathBuf) -> Result<(), ClvmZkError> {
 // ============================================================================
 
 fn spend_to_puzzle_command(
-    data_dir: &PathBuf,
+    data_dir: &Path,
     from: &str,
     amount: u64,
     program: &str,
@@ -1816,7 +1817,7 @@ fn spend_to_puzzle_command(
 }
 
 fn spend_to_wallet_command(
-    data_dir: &PathBuf,
+    data_dir: &Path,
     program: &str,
     params: &str,
     to: &str,
@@ -1957,7 +1958,7 @@ fn spend_to_wallet_command(
     Ok(())
 }
 
-fn observer_command(data_dir: &PathBuf, action: ObserverAction) -> Result<(), ClvmZkError> {
+fn observer_command(data_dir: &Path, action: ObserverAction) -> Result<(), ClvmZkError> {
     use crate::wallet::Network;
 
     let mut state = SimulatorState::load(data_dir)?;

--- a/src/crypto_utils.rs
+++ b/src/crypto_utils.rs
@@ -3,6 +3,13 @@
 
 use sha2::{Digest, Sha256};
 
+/// sha256 hash function for general use
+pub fn hash_data_default(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
 /// make viewing tag for coin discovery
 ///
 /// viewing tags are 4-byte ids that let wallets scan for coins efficiently
@@ -47,34 +54,6 @@ pub fn find_coin_index_by_viewing_tag(
         }
     }
     None
-}
-
-/// make canonical nullifier with domain separation and puzzle binding
-///
-/// this implements the hardened nullifier algorithm v1.0 with:
-/// - domain separation to prevent cross-protocol attacks
-/// - puzzle binding for future features
-/// - deterministic output for the same inputs
-///
-/// design note: the puzzle_hash binding is defensive programming.
-/// in the current protocol, each spend_secret should be globally unique,
-/// so simple sha256(spend_secret) would work for double-spend prevention.
-/// but puzzle_hash binding gives us:
-/// - future-proofing for protocol extensions
-/// - extra protection against bugs
-/// - flexibility for future features
-///
-/// returns 32-byte nullifier that uniquely identifies this spend
-pub fn generate_nullifier(spend_secret: &[u8; 32], puzzle_hash: &[u8; 32]) -> [u8; 32] {
-    // use same single-hash approach as guest-side for consistency
-    let mut combined = Vec::with_capacity(64 + 32);
-    combined.extend_from_slice(b"clvm_zk_nullifier_v1.0");
-    combined.extend_from_slice(spend_secret);
-    combined.extend_from_slice(puzzle_hash);
-
-    let mut hasher = Sha256::new();
-    hasher.update(&combined);
-    hasher.finalize().into()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,22 +141,6 @@ impl ClvmZkProver {
         backend.prove_program(expression, parameters)
     }
 
-    pub fn prove_with_nullifier(
-        expression: &str,
-        parameters: &[ProgramParameter],
-        spend_secret: [u8; 32],
-    ) -> Result<ZKClvmResult, ClvmZkError> {
-        if parameters.len() > 10 {
-            return Err(ClvmZkError::InvalidProgram(
-                "Too many parameters (maximum 10: a-j)".to_string(),
-            ));
-        }
-
-        Self::validate_chialisp_syntax(expression)?;
-        let backend = crate::backends::backend()?;
-        backend.prove_with_nullifier(expression, parameters, spend_secret)
-    }
-
     /// prove spending with serial commitment verification and merkle membership
     #[allow(clippy::too_many_arguments)]
     pub fn prove_with_serial_commitment(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ pub mod simulator;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing_helpers;
 pub mod wallet;
-pub use clvm_zk_core::{ClvmResult, ClvmZkError, Input, ProgramParameter, ZKClvmResult};
+pub use clvm_zk_core::{
+    ClvmResult, ClvmZkError, Input, InputWithSerial, ProgramParameter, ZKClvmResult,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OperandInput {
@@ -152,7 +154,8 @@ impl ClvmZkProver {
         serial_commitment: [u8; 32],
         merkle_root: [u8; 32],
         leaf_index: usize,
-        puzzle_hash: [u8; 32],
+        program_hash: [u8; 32],
+        amount: u64,
     ) -> Result<ZKClvmResult, ClvmZkError> {
         if parameters.len() > 10 {
             return Err(ClvmZkError::InvalidProgram(
@@ -162,18 +165,19 @@ impl ClvmZkProver {
 
         Self::validate_chialisp_syntax(expression)?;
 
-        let input = clvm_zk_core::backend_utils::prepare_guest_inputs_with_serial(
-            expression,
-            parameters,
-            coin_secrets.serial_number,
-            coin_secrets.serial_randomness,
+        let input = InputWithSerial {
+            chialisp_source: expression.to_string(),
+            program_parameters: parameters.to_vec(),
+            serial_number: coin_secrets.serial_number,
+            serial_randomness: coin_secrets.serial_randomness,
             merkle_path,
             coin_commitment,
             serial_commitment,
             merkle_root,
             leaf_index,
-            puzzle_hash,
-        );
+            program_hash,
+            amount,
+        };
 
         #[cfg(feature = "risc0")]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod simulator;
 pub mod testing_helpers;
 pub mod wallet;
 pub use clvm_zk_core::{
-    ClvmResult, ClvmZkError, Input, InputWithSerial, ProgramParameter, ZKClvmResult,
+    ClvmResult, ClvmZkError, Input, ProgramParameter, SerialCommitmentData, ZKClvmResult,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -165,18 +165,20 @@ impl ClvmZkProver {
 
         Self::validate_chialisp_syntax(expression)?;
 
-        let input = InputWithSerial {
+        let input = Input {
             chialisp_source: expression.to_string(),
             program_parameters: parameters.to_vec(),
-            serial_number: coin_secrets.serial_number,
-            serial_randomness: coin_secrets.serial_randomness,
-            merkle_path,
-            coin_commitment,
-            serial_commitment,
-            merkle_root,
-            leaf_index,
-            program_hash,
-            amount,
+            serial_commitment_data: Some(SerialCommitmentData {
+                serial_number: coin_secrets.serial_number,
+                serial_randomness: coin_secrets.serial_randomness,
+                merkle_path,
+                coin_commitment,
+                serial_commitment,
+                merkle_root,
+                leaf_index,
+                program_hash,
+                amount,
+            }),
         };
 
         #[cfg(feature = "risc0")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ impl ClvmZkProver {
         coin_commitment: [u8; 32],
         serial_commitment: [u8; 32],
         merkle_root: [u8; 32],
+        leaf_index: usize,
         puzzle_hash: [u8; 32],
     ) -> Result<ZKClvmResult, ClvmZkError> {
         if parameters.len() > 10 {
@@ -186,6 +187,7 @@ impl ClvmZkProver {
             coin_commitment,
             serial_commitment,
             merkle_root,
+            leaf_index,
             puzzle_hash,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ impl ClvmZkProver {
     }
 
     /// prove spending with serial commitment verification and merkle membership
+    #[allow(clippy::too_many_arguments)]
     pub fn prove_with_serial_commitment(
         expression: &str,
         parameters: &[ProgramParameter],
@@ -203,7 +204,7 @@ impl ClvmZkProver {
         #[cfg(feature = "mock")]
         {
             let backend = clvm_zk_mock::MockBackend::new()?;
-            return backend.prove_with_input(input);
+            backend.prove_with_input(input)
         }
     }
 }

--- a/src/protocol/encrypted_notes.rs
+++ b/src/protocol/encrypted_notes.rs
@@ -1,0 +1,181 @@
+//! Encrypted payment notes for cross-wallet transfers
+//!
+//! This module implements the payment note system that allows alice to send coins to bob
+//! even when bob is offline. The note contains the serial_number and serial_randomness
+//! needed to spend the coin, encrypted to bob's viewing key.
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit, OsRng},
+    ChaCha20Poly1305, Nonce,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
+
+/// Encrypted payment note that can be decrypted by recipient
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptedNote {
+    /// Ephemeral public key for ECDH
+    pub ephemeral_key: [u8; 32],
+    
+    /// Encrypted payload containing PaymentNote
+    pub ciphertext: Vec<u8>,
+    
+    /// Nonce for ChaCha20-Poly1305
+    pub nonce: [u8; 12],
+}
+
+/// Decrypted payment note containing coin secrets and metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaymentNote {
+    /// Serial number (becomes nullifier when spent)
+    pub serial_number: [u8; 32],
+    
+    /// Serial randomness (proves knowledge of serial)
+    pub serial_randomness: [u8; 32],
+    
+    /// Coin amount
+    pub amount: u64,
+    
+    /// Puzzle hash for the coin
+    pub puzzle_hash: [u8; 32],
+    
+    /// Optional memo (arbitrary data)
+    pub memo: Vec<u8>,
+}
+
+impl EncryptedNote {
+    /// Encrypt a payment note to a recipient's viewing public key
+    ///
+    /// Uses ECDH with ephemeral key + ChaCha20-Poly1305 for authenticated encryption
+    pub fn encrypt(
+        recipient_viewing_public: &[u8; 32],
+        note: &PaymentNote,
+    ) -> Result<Self, String> {
+        // Generate ephemeral keypair for ECDH
+        let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
+        let ephemeral_public = PublicKey::from(&ephemeral_secret);
+        
+        // Perform ECDH
+        let recipient_public = PublicKey::from(*recipient_viewing_public);
+        let shared_secret = ephemeral_secret.diffie_hellman(&recipient_public);
+        
+        // Derive encryption key from shared secret
+        let key = Self::derive_encryption_key(shared_secret.as_bytes());
+        
+        // Serialize payment note
+        let plaintext = serde_json::to_vec(note)
+            .map_err(|e| format!("failed to serialize note: {e}"))?;
+        
+        // Generate random nonce
+        let nonce_bytes = rand::random::<[u8; 12]>();
+        let nonce = Nonce::from(nonce_bytes);
+        
+        // Encrypt with ChaCha20-Poly1305
+        let cipher = ChaCha20Poly1305::new(&key.into());
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext.as_ref())
+            .map_err(|e| format!("encryption failed: {e}"))?;
+        
+        Ok(EncryptedNote {
+            ephemeral_key: ephemeral_public.to_bytes(),
+            ciphertext,
+            nonce: nonce_bytes,
+        })
+    }
+    
+    /// Decrypt a payment note using recipient's viewing private key
+    pub fn decrypt(
+        &self,
+        viewing_private: &[u8; 32],
+    ) -> Result<PaymentNote, String> {
+        // Reconstruct ephemeral public key
+        let ephemeral_public = PublicKey::from(self.ephemeral_key);
+        
+        // Perform ECDH with our private key
+        let static_secret = StaticSecret::from(*viewing_private);
+        let shared_secret = static_secret.diffie_hellman(&ephemeral_public);
+        
+        // Derive same encryption key
+        let key = Self::derive_encryption_key(shared_secret.as_bytes());
+        
+        // Decrypt with ChaCha20-Poly1305
+        let nonce = Nonce::from(self.nonce);
+        let cipher = ChaCha20Poly1305::new(&key.into());
+        let plaintext = cipher
+            .decrypt(&nonce, self.ciphertext.as_ref())
+            .map_err(|_| "decryption failed (wrong key or corrupted data)")?;
+        
+        // Deserialize payment note
+        serde_json::from_slice(&plaintext)
+            .map_err(|e| format!("failed to deserialize note: {e}"))
+    }
+    
+    /// Derive encryption key from ECDH shared secret using HKDF
+    fn derive_encryption_key(shared_secret: &[u8]) -> [u8; 32] {
+        // Use SHA256 as simple KDF
+        // In production, use proper HKDF
+        let mut hasher = Sha256::new();
+        hasher.update(b"clvm_zk_note_encryption_v1");
+        hasher.update(shared_secret);
+        hasher.finalize().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        // Generate viewing keypair
+        let viewing_private = rand::random::<[u8; 32]>();
+        let viewing_public = PublicKey::from(&StaticSecret::from(viewing_private)).to_bytes();
+        
+        // Create payment note
+        let note = PaymentNote {
+            serial_number: rand::random(),
+            serial_randomness: rand::random(),
+            amount: 1000,
+            puzzle_hash: rand::random(),
+            memo: b"test payment".to_vec(),
+        };
+        
+        // Encrypt
+        let encrypted = EncryptedNote::encrypt(&viewing_public, &note)
+            .expect("encryption should succeed");
+        
+        // Decrypt
+        let decrypted = encrypted.decrypt(&viewing_private)
+            .expect("decryption should succeed");
+        
+        // Verify
+        assert_eq!(decrypted.serial_number, note.serial_number);
+        assert_eq!(decrypted.serial_randomness, note.serial_randomness);
+        assert_eq!(decrypted.amount, note.amount);
+        assert_eq!(decrypted.puzzle_hash, note.puzzle_hash);
+        assert_eq!(decrypted.memo, note.memo);
+    }
+    
+    #[test]
+    fn test_decrypt_with_wrong_key_fails() {
+        let viewing_private1 = rand::random::<[u8; 32]>();
+        let viewing_public1 = PublicKey::from(&StaticSecret::from(viewing_private1)).to_bytes();
+        
+        let viewing_private2 = rand::random::<[u8; 32]>();
+        
+        let note = PaymentNote {
+            serial_number: rand::random(),
+            serial_randomness: rand::random(),
+            amount: 1000,
+            puzzle_hash: rand::random(),
+            memo: vec![],
+        };
+        
+        let encrypted = EncryptedNote::encrypt(&viewing_public1, &note).unwrap();
+        
+        // Try to decrypt with wrong key
+        let result = encrypted.decrypt(&viewing_private2);
+        assert!(result.is_err());
+    }
+}

--- a/src/protocol/encrypted_notes.rs
+++ b/src/protocol/encrypted_notes.rs
@@ -17,10 +17,10 @@ use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 pub struct EncryptedNote {
     /// Ephemeral public key for ECDH
     pub ephemeral_key: [u8; 32],
-    
+
     /// Encrypted payload containing PaymentNote
     pub ciphertext: Vec<u8>,
-    
+
     /// Nonce for ChaCha20-Poly1305
     pub nonce: [u8; 12],
 }
@@ -30,16 +30,16 @@ pub struct EncryptedNote {
 pub struct PaymentNote {
     /// Serial number (becomes nullifier when spent)
     pub serial_number: [u8; 32],
-    
+
     /// Serial randomness (proves knowledge of serial)
     pub serial_randomness: [u8; 32],
-    
+
     /// Coin amount
     pub amount: u64,
-    
+
     /// Puzzle hash for the coin
     pub puzzle_hash: [u8; 32],
-    
+
     /// Optional memo (arbitrary data)
     pub memo: Vec<u8>,
 }
@@ -55,62 +55,58 @@ impl EncryptedNote {
         // Generate ephemeral keypair for ECDH
         let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
         let ephemeral_public = PublicKey::from(&ephemeral_secret);
-        
+
         // Perform ECDH
         let recipient_public = PublicKey::from(*recipient_viewing_public);
         let shared_secret = ephemeral_secret.diffie_hellman(&recipient_public);
-        
+
         // Derive encryption key from shared secret
         let key = Self::derive_encryption_key(shared_secret.as_bytes());
-        
+
         // Serialize payment note
-        let plaintext = serde_json::to_vec(note)
-            .map_err(|e| format!("failed to serialize note: {e}"))?;
-        
+        let plaintext =
+            serde_json::to_vec(note).map_err(|e| format!("failed to serialize note: {e}"))?;
+
         // Generate random nonce
         let nonce_bytes = rand::random::<[u8; 12]>();
         let nonce = Nonce::from(nonce_bytes);
-        
+
         // Encrypt with ChaCha20-Poly1305
         let cipher = ChaCha20Poly1305::new(&key.into());
         let ciphertext = cipher
             .encrypt(&nonce, plaintext.as_ref())
             .map_err(|e| format!("encryption failed: {e}"))?;
-        
+
         Ok(EncryptedNote {
             ephemeral_key: ephemeral_public.to_bytes(),
             ciphertext,
             nonce: nonce_bytes,
         })
     }
-    
+
     /// Decrypt a payment note using recipient's viewing private key
-    pub fn decrypt(
-        &self,
-        viewing_private: &[u8; 32],
-    ) -> Result<PaymentNote, String> {
+    pub fn decrypt(&self, viewing_private: &[u8; 32]) -> Result<PaymentNote, String> {
         // Reconstruct ephemeral public key
         let ephemeral_public = PublicKey::from(self.ephemeral_key);
-        
+
         // Perform ECDH with our private key
         let static_secret = StaticSecret::from(*viewing_private);
         let shared_secret = static_secret.diffie_hellman(&ephemeral_public);
-        
+
         // Derive same encryption key
         let key = Self::derive_encryption_key(shared_secret.as_bytes());
-        
+
         // Decrypt with ChaCha20-Poly1305
         let nonce = Nonce::from(self.nonce);
         let cipher = ChaCha20Poly1305::new(&key.into());
         let plaintext = cipher
             .decrypt(&nonce, self.ciphertext.as_ref())
             .map_err(|_| "decryption failed (wrong key or corrupted data)")?;
-        
+
         // Deserialize payment note
-        serde_json::from_slice(&plaintext)
-            .map_err(|e| format!("failed to deserialize note: {e}"))
+        serde_json::from_slice(&plaintext).map_err(|e| format!("failed to deserialize note: {e}"))
     }
-    
+
     /// Derive encryption key from ECDH shared secret using HKDF
     fn derive_encryption_key(shared_secret: &[u8]) -> [u8; 32] {
         // Use SHA256 as simple KDF
@@ -125,13 +121,13 @@ impl EncryptedNote {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_encrypt_decrypt_roundtrip() {
         // Generate viewing keypair
         let viewing_private = rand::random::<[u8; 32]>();
         let viewing_public = PublicKey::from(&StaticSecret::from(viewing_private)).to_bytes();
-        
+
         // Create payment note
         let note = PaymentNote {
             serial_number: rand::random(),
@@ -140,15 +136,16 @@ mod tests {
             puzzle_hash: rand::random(),
             memo: b"test payment".to_vec(),
         };
-        
+
         // Encrypt
-        let encrypted = EncryptedNote::encrypt(&viewing_public, &note)
-            .expect("encryption should succeed");
-        
+        let encrypted =
+            EncryptedNote::encrypt(&viewing_public, &note).expect("encryption should succeed");
+
         // Decrypt
-        let decrypted = encrypted.decrypt(&viewing_private)
+        let decrypted = encrypted
+            .decrypt(&viewing_private)
             .expect("decryption should succeed");
-        
+
         // Verify
         assert_eq!(decrypted.serial_number, note.serial_number);
         assert_eq!(decrypted.serial_randomness, note.serial_randomness);
@@ -156,14 +153,14 @@ mod tests {
         assert_eq!(decrypted.puzzle_hash, note.puzzle_hash);
         assert_eq!(decrypted.memo, note.memo);
     }
-    
+
     #[test]
     fn test_decrypt_with_wrong_key_fails() {
         let viewing_private1 = rand::random::<[u8; 32]>();
         let viewing_public1 = PublicKey::from(&StaticSecret::from(viewing_private1)).to_bytes();
-        
+
         let viewing_private2 = rand::random::<[u8; 32]>();
-        
+
         let note = PaymentNote {
             serial_number: rand::random(),
             serial_randomness: rand::random(),
@@ -171,9 +168,9 @@ mod tests {
             puzzle_hash: rand::random(),
             memo: vec![],
         };
-        
+
         let encrypted = EncryptedNote::encrypt(&viewing_public1, &note).unwrap();
-        
+
         // Try to decrypt with wrong key
         let result = encrypted.decrypt(&viewing_private2);
         assert!(result.is_err());

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -31,7 +31,7 @@
 //!
 //! println!("Coin amount: {}", coin.amount);
 //! println!("Serial commitment: {}", hex::encode(coin.serial_commitment.0));
-//! println!("Nullifier (keep secret): {}", hex::encode(secrets.nullifier()));
+//! println!("Serial number (keep secret): {}", hex::encode(secrets.serial_number()));
 //! ```
 
 pub mod encrypted_notes;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -22,18 +22,16 @@
 //! ## Usage Example
 //!
 //! ```rust
-//! use clvm_zk::protocol::{PrivateCoin, Spender};
-//! use clvm_zk::ProgramParameter;
+//! use clvm_zk::protocol::PrivateCoin;
+//! use sha2::{Digest, Sha256};
 //!
-//! // Create a private coin
-//! let coin = PrivateCoin::new_random_from_program("(mod (a b) (+ a b))", 1000);
-//! println!("Coin nullifier: {}", coin.nullifier_hex());
+//! // Create a private coin with random serial commitment
+//! let puzzle_hash = Sha256::digest(b"my_puzzle").into();
+//! let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
 //!
-//! // Spend the coin (will be available after Task 1.3)
-//! // let bundle = Spender::create_spend(&coin, &[
-//! //     ProgramParameter::int(5),
-//! //     ProgramParameter::int(3)
-//! // ])?;
+//! println!("Coin amount: {}", coin.amount);
+//! println!("Serial commitment: {}", hex::encode(coin.serial_commitment.0));
+//! println!("Nullifier (keep secret): {}", hex::encode(secrets.nullifier()));
 //! ```
 
 pub mod puzzles;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -34,11 +34,13 @@
 //! println!("Nullifier (keep secret): {}", hex::encode(secrets.nullifier()));
 //! ```
 
+pub mod encrypted_notes;
 pub mod puzzles;
 pub mod spender;
 pub mod structures;
 
 // Re-export main types for convenient access
+pub use encrypted_notes::{EncryptedNote, PaymentNote};
 pub use puzzles::{
     create_password_puzzle, create_password_puzzle_program, create_password_spend_parameters,
     create_password_spend_params, create_signature_puzzle, create_signature_spend_params,

--- a/src/protocol/puzzles.rs
+++ b/src/protocol/puzzles.rs
@@ -205,8 +205,8 @@ mod tests {
         ); // Proper Chialisp syntax
 
         // Create a coin with this puzzle
-        let spend_secret = [0x42; 32];
-        let _coin = PrivateCoin::new(spend_secret, puzzle_hash, 1000);
+        let _ = [0x42; 32]; // ignored for test
+        let _coin = PrivateCoin::new_random(puzzle_hash, 1000);
 
         // Create a test message and signature
         let message = b"spend_authorization_test";

--- a/src/protocol/spender.rs
+++ b/src/protocol/spender.rs
@@ -13,6 +13,7 @@ impl Spender {
         secrets: &CoinSecrets,
         merkle_path: Vec<[u8; 32]>,
         merkle_root: [u8; 32],
+        leaf_index: usize,
     ) -> Result<PrivateSpendBundle, ProtocolError> {
         coin.validate()
             .map_err(|e| ProtocolError::ProofGenerationFailed(format!("invalid coin: {e}")))?;
@@ -34,6 +35,7 @@ impl Spender {
             coin_commitment.0,
             coin.serial_commitment.0,
             merkle_root,
+            leaf_index,
             coin.puzzle_hash,
         )
         .map_err(|e| ProtocolError::ProofGenerationFailed(format!("zk proof failed: {e}")))?;

--- a/src/protocol/spender.rs
+++ b/src/protocol/spender.rs
@@ -1,205 +1,78 @@
 use crate::protocol::{PrivateCoin, PrivateSpendBundle, ProtocolError};
 use crate::ProgramParameter;
-use sha2::{Digest, Sha256};
+use clvm_zk_core::coin_commitment::{CoinCommitment, CoinSecrets};
 
-/// safe way to spend private coins with automatic nullifier generation
-///
-/// the spender makes sure you can't mess up by:
-/// 1. automatically including the spend_secret in zk proofs
-/// 2. computing nullifiers the right way
-/// 3. packaging everything into secure spend bundles
-/// 4. preventing access to the unsafe low-level apis
-///
-/// what you get:
-/// - unique nullifier for every spend (prevents double spending)
-/// - your secrets stay hidden in zk proofs
-/// - puzzle hash verification makes sure the program is correct
-///
-/// example:
-///
-/// ```rust
-/// use clvm_zk::protocol::{PrivateCoin, Spender};
-/// use clvm_zk::ProgramParameter;
-///
-/// // make a private coin
-/// let coin = PrivateCoin::new_random_from_program("(mod (a b) (+ a b))", 1000);
-///
-/// // spend it safely
-/// let bundle = Spender::create_spend(
-///     &coin,
-///     "(mod (a b) (+ a b))",  // the actual program code in proper Chialisp syntax
-///     &[ProgramParameter::int(5), ProgramParameter::int(3)]
-/// ).expect("Failed to create spend");
-///
-/// // you get back:
-/// // - bundle.nullifier: unique id preventing double-spend
-/// // - bundle.zk_proof: zk proof that spend is valid
-/// // - bundle.public_conditions: clvm output for blockchain processing
-/// ```
 pub struct Spender;
 
 impl Spender {
-    /// spend a private coin and get back a secure bundle
-    ///
-    /// this is the main function for spending coins. it handles all the security stuff automatically.
-    ///
-    /// what it does:
-    /// 1. checks that puzzle_code actually matches the coin's puzzle_hash
-    /// 2. makes a nullifier from the coin's spend_secret
-    /// 3. creates a zk proof without revealing your secrets
-    /// 4. packages everything into a secure bundle
-    ///
-    /// you get back a complete spend bundle ready for the blockchain with:
-    /// - zk proof that everything is valid
-    /// - public nullifier to prevent double spending
-    /// - clvm output for the blockchain to process
-    pub fn create_spend(
+    /// spend a coin by proving knowledge of secrets and merkle membership
+    pub fn create_spend_with_serial(
         coin: &PrivateCoin,
         puzzle_code: &str,
         solution_params: &[ProgramParameter],
+        secrets: &CoinSecrets,
+        merkle_path: Vec<[u8; 32]>,
+        merkle_root: [u8; 32],
     ) -> Result<PrivateSpendBundle, ProtocolError> {
-        // 1. make sure the coin is valid before we do anything
         coin.validate()
-            .map_err(|e| ProtocolError::ProofGenerationFailed(format!("Invalid coin: {e}")))?;
+            .map_err(|e| ProtocolError::ProofGenerationFailed(format!("invalid coin: {e}")))?;
 
-        // 2. check that puzzle_code actually matches what's in the coin
-        // TODO: Update to use guest-side compilation when needed
-        // For now, skip this check since we don't have the old hash_template method
-        let computed_hash = coin.puzzle_hash; // Assume it matches for now
-        if computed_hash != coin.puzzle_hash {
-            return Err(ProtocolError::InvalidSpendSecret(format!(
-                "Puzzle code hash mismatch: expected {}, computed {}",
-                hex::encode(coin.puzzle_hash),
-                hex::encode(computed_hash)
-            )));
-        }
+        let coin_commitment = CoinCommitment::compute(
+            coin.amount,
+            &coin.puzzle_hash,
+            &coin.serial_commitment,
+            crate::crypto_utils::hash_data_default,
+        );
 
-        // 3. get the nullifier (this prevents double spending)
-        let expected_nullifier = coin.nullifier();
+        let expected_nullifier = secrets.serial_number;
 
-        // 4. create the zk proof using the right api
-        let zkvm_result = crate::ClvmZkProver::prove_with_nullifier(
+        let zkvm_result = crate::ClvmZkProver::prove_with_serial_commitment(
             puzzle_code,
             solution_params,
-            coin.spend_secret,
+            secrets,
+            merkle_path,
+            coin_commitment.0,
+            coin.serial_commitment.0,
+            merkle_root,
+            coin.puzzle_hash,
         )
-        .map_err(|e| ProtocolError::ProofGenerationFailed(format!("ZK proof failed: {e}")))?;
+        .map_err(|e| ProtocolError::ProofGenerationFailed(format!("zk proof failed: {e}")))?;
 
-        // 5. double check the nullifier is what we expected
         let actual_nullifier = zkvm_result
             .proof_output
             .nullifier
-            .ok_or_else(|| ProtocolError::InvalidNullifier("No nullifier in proof".to_string()))?;
+            .ok_or_else(|| ProtocolError::InvalidNullifier("no nullifier in proof".to_string()))?;
+
         if actual_nullifier != expected_nullifier {
             return Err(ProtocolError::InvalidNullifier(format!(
-                "Nullifier mismatch: expected {}, got {}",
+                "nullifier mismatch: expected {}, got {}",
                 hex::encode(expected_nullifier),
                 hex::encode(actual_nullifier)
             )));
         }
 
-        // 6. package everything up into a secure bundle
         let spend_bundle = PrivateSpendBundle::new(
             zkvm_result.proof_bytes,
             actual_nullifier,
             zkvm_result.proof_output.clvm_res.output.clone(),
         );
 
-        // 7. FINAL VALIDATION: Ensure bundle is well-formed
         spend_bundle
             .validate()
-            .map_err(|e| ProtocolError::ProofGenerationFailed(format!("Invalid bundle: {e}")))?;
+            .map_err(|e| ProtocolError::ProofGenerationFailed(format!("invalid bundle: {e}")))?;
 
         Ok(spend_bundle)
     }
 
-    /// Create multiple spend bundles atomically (for batch transactions)
-    ///
-    /// This ensures that either all spends succeed or none do, preventing
-    /// partial failures that could lead to inconsistent state.
-    ///
-    /// # Arguments
-    ///
-    /// * `spends` - Vector of (coin, puzzle_code, solution_params) tuples
-    ///
-    /// # Security Properties
-    ///
-    /// - **Atomicity**: All-or-nothing spend creation
-    /// - **Nullifier Uniqueness**: Prevents duplicate nullifiers in batch
-    /// - **Program Integrity**: Validates all puzzle hashes
-    ///
-    /// # Returns
-    ///
-    /// Vector of spend bundles in the same order as inputs
-    pub fn create_spend_batch(
-        spends: &[(&PrivateCoin, &str, &[ProgramParameter])],
-    ) -> Result<Vec<PrivateSpendBundle>, ProtocolError> {
-        // 1. SECURITY: Pre-validate all coins and detect duplicate nullifiers
-        let mut nullifiers = std::collections::HashSet::new();
-        for (coin, puzzle_code, _) in spends {
-            coin.validate()
-                .map_err(|e| ProtocolError::InvalidSpendSecret(format!("Invalid coin: {e}")))?;
-
-            // Check for duplicate nullifiers in the batch
-            let nullifier = coin.nullifier();
-            if !nullifiers.insert(nullifier) {
-                return Err(ProtocolError::InvalidNullifier(format!(
-                    "Duplicate nullifier in batch: {}",
-                    hex::encode(nullifier)
-                )));
-            }
-
-            // Verify puzzle hash
-            let computed_hash = Sha256::digest(puzzle_code.as_bytes());
-            if computed_hash[..] != coin.puzzle_hash {
-                return Err(ProtocolError::InvalidSpendSecret(format!(
-                    "Puzzle code hash mismatch for coin {}: expected {}, computed {}",
-                    hex::encode(nullifier),
-                    hex::encode(coin.puzzle_hash),
-                    hex::encode(computed_hash)
-                )));
-            }
-        }
-
-        // 2. CREATE ALL SPEND BUNDLES: Process each spend
-        let mut bundles = Vec::with_capacity(spends.len());
-        for (coin, puzzle_code, solution_params) in spends {
-            let bundle = Self::create_spend(coin, puzzle_code, solution_params)?;
-            bundles.push(bundle);
-        }
-
-        Ok(bundles)
-    }
-
-    /// Verify that a spend bundle was created from a specific coin (without revealing the coin)
-    ///
-    /// This allows public verification that a nullifier corresponds to a validly spent coin
-    /// without revealing any private information about the coin itself.
-    ///
-    /// # Arguments
-    ///
-    /// * `bundle` - The spend bundle to verify
-    /// * `expected_nullifier` - The nullifier that should be in the bundle
-    ///
-    /// # Returns
-    ///
-    /// `true` if the bundle contains the expected nullifier and is well-formed
+    /// verify that a spend bundle contains the expected nullifier
     pub fn verify_nullifier(
         bundle: &PrivateSpendBundle,
         expected_nullifier: &[u8; 32],
     ) -> Result<bool, ProtocolError> {
-        // Validate bundle structure first
         bundle
             .validate()
             .map_err(|e| ProtocolError::SerializationError(format!("Invalid bundle: {e}")))?;
 
-        // Check nullifier match
         Ok(bundle.nullifier == *expected_nullifier)
     }
-
-    // TODO: implement puzzle hash extraction via backend system
-    // would need to extend backend trait to extract public inputs from proofs
-    // pub fn extract_puzzle_hash(bundle: &PrivateSpendBundle) -> Result<[u8; 32], ProtocolError> {
-    //     unimplemented!("puzzle hash extraction needs backend trait extension")
-    // }
 }

--- a/src/protocol/structures.rs
+++ b/src/protocol/structures.rs
@@ -34,11 +34,7 @@ pub struct PrivateCoin {
 }
 
 impl PrivateCoin {
-    pub fn new(
-        puzzle_hash: [u8; 32],
-        amount: u64,
-        serial_commitment: SerialCommitment,
-    ) -> Self {
+    pub fn new(puzzle_hash: [u8; 32], amount: u64, serial_commitment: SerialCommitment) -> Self {
         Self {
             puzzle_hash,
             amount,
@@ -81,7 +77,8 @@ impl PrivateCoin {
         );
 
         let coin = Self::new(puzzle_hash, amount, serial_commitment);
-        let secrets = clvm_zk_core::coin_commitment::CoinSecrets::new(serial_number, serial_randomness);
+        let secrets =
+            clvm_zk_core::coin_commitment::CoinSecrets::new(serial_number, serial_randomness);
 
         (coin, secrets)
     }
@@ -220,7 +217,8 @@ mod tests {
 
         assert_eq!(coin.amount, amount);
 
-        let expected_hash = clvm_zk_core::chialisp::compile_chialisp_template_hash_default(puzzle_code).unwrap();
+        let expected_hash =
+            clvm_zk_core::chialisp::compile_chialisp_template_hash_default(puzzle_code).unwrap();
         assert_eq!(coin.puzzle_hash, expected_hash);
     }
 

--- a/src/protocol/structures.rs
+++ b/src/protocol/structures.rs
@@ -228,7 +228,7 @@ mod tests {
         let (coin1, secrets1) = PrivateCoin::new_with_secrets(puzzle_hash, 100);
         let (coin2, secrets2) = PrivateCoin::new_with_secrets(puzzle_hash, 100);
 
-        assert_ne!(secrets1.nullifier(), secrets2.nullifier());
+        assert_ne!(secrets1.serial_number(), secrets2.serial_number());
         assert_eq!(coin1.puzzle_hash, coin2.puzzle_hash);
     }
 
@@ -238,8 +238,8 @@ mod tests {
         let (coin1, secrets1) = PrivateCoin::new_with_secrets(puzzle_hash, 100);
         let (coin2, secrets2) = PrivateCoin::new_with_secrets(puzzle_hash, 100);
 
-        // Random coins should have different nullifiers
-        assert_ne!(secrets1.nullifier(), secrets2.nullifier());
+        // Random coins should have different serial_numbers
+        assert_ne!(secrets1.serial_number(), secrets2.serial_number());
         assert_eq!(coin1.puzzle_hash, coin2.puzzle_hash); // Same puzzle
     }
 

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -101,17 +101,25 @@ impl CLVMZkSimulator {
             new_nullifiers.push(nullifier);
         }
 
-        let merkle_root = self.coin_tree.root().ok_or_else(|| {
-            SimulatorError::TestFailed("merkle tree has no root".to_string())
-        })?;
-        
+        let merkle_root = self
+            .coin_tree
+            .root()
+            .ok_or_else(|| SimulatorError::TestFailed("merkle tree has no root".to_string()))?;
+
         let mut spend_bundles = Vec::new();
         for (coin, program, params, secrets) in spends {
             let merkle_path = self.get_merkle_path(&coin).ok_or_else(|| {
                 SimulatorError::TestFailed("coin not found in merkle tree".to_string())
             })?;
 
-            match Spender::create_spend_with_serial(&coin, &program, &params, &secrets, merkle_path, merkle_root) {
+            match Spender::create_spend_with_serial(
+                &coin,
+                &program,
+                &params,
+                &secrets,
+                merkle_path,
+                merkle_root,
+            ) {
                 Ok(bundle) => spend_bundles.push(bundle),
                 Err(e) => return Err(SimulatorError::ProofGeneration(format!("{:?}", e))),
             }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -20,7 +20,7 @@ pub struct CLVMZkSimulator {
     coin_tree: MerkleTree<MerkleHasher>,
     #[serde(with = "hex_hashmap")]
     commitment_to_index: HashMap<[u8; 32], usize>,
-    merkle_leaves: Vec<[u8; 32]>,  // persisted leaves to rebuild tree
+    merkle_leaves: Vec<[u8; 32]>, // persisted leaves to rebuild tree
     transactions: Vec<SimulatedTransaction>,
     block_height: u64,
 }
@@ -137,7 +137,7 @@ impl CLVMZkSimulator {
         let leaf_index = self.coin_tree.leaves_len();
         self.coin_tree.insert(coin_commitment.0);
         self.coin_tree.commit();
-        self.merkle_leaves.push(coin_commitment.0);  // track leaf for persistence
+        self.merkle_leaves.push(coin_commitment.0); // track leaf for persistence
         self.commitment_to_index
             .insert(coin_commitment.0, leaf_index);
 
@@ -186,10 +186,11 @@ impl CLVMZkSimulator {
 
         let mut spend_bundles = Vec::new();
         for (coin, program, params, secrets) in spends {
-            let (merkle_path, leaf_index) = self.get_merkle_path_and_index(&coin).ok_or_else(|| {
-                SimulatorError::TestFailed("coin not found in merkle tree".to_string())
-            })?;
-            
+            let (merkle_path, leaf_index) =
+                self.get_merkle_path_and_index(&coin).ok_or_else(|| {
+                    SimulatorError::TestFailed("coin not found in merkle tree".to_string())
+                })?;
+
             match Spender::create_spend_with_serial(
                 &coin,
                 &program,

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -1,30 +1,21 @@
-// ============================================================================
-// CLVM-ZK Protocol Simulator
-// Simulates blockchain without needing actual infrastructure
-// ============================================================================
+// blockchain simulator for testing protocol
 
-use crate::protocol::{
-    create_signature_spend_params, PrivateCoin, PrivateSpendBundle, ProtocolError, Spender,
-};
+use crate::protocol::{PrivateCoin, PrivateSpendBundle, ProtocolError, Spender};
+use clvm_zk_core::coin_commitment::CoinCommitment;
+use rs_merkle::{algorithms::Sha256 as MerkleHasher, MerkleTree};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-// ============================================================================
-// Simulator Core
-// ============================================================================
-
-/// Simulated blockchain state for testing protocol scenarios
-#[derive(Debug, Clone)]
+/// simulated blockchain state for testing
+#[derive(Clone)]
 pub struct CLVMZkSimulator {
-    /// Global nullifier set (prevents double-spends)
     nullifier_set: HashSet<[u8; 32]>,
-    /// UTXO set: nullifier -> coin info
     utxo_set: HashMap<[u8; 32], CoinInfo>,
-    /// Transaction history
+    coin_tree: MerkleTree<MerkleHasher>,
+    commitment_to_index: HashMap<[u8; 32], usize>,
     transactions: Vec<SimulatedTransaction>,
-    /// Block height for testing
     block_height: u64,
 }
 
@@ -35,116 +26,97 @@ impl Default for CLVMZkSimulator {
 }
 
 impl CLVMZkSimulator {
-    /// Create new simulator
     pub fn new() -> Self {
         Self {
             nullifier_set: HashSet::new(),
             utxo_set: HashMap::new(),
+            coin_tree: MerkleTree::<MerkleHasher>::new(),
+            commitment_to_index: HashMap::new(),
             transactions: Vec::new(),
             block_height: 0,
         }
     }
 
-    /// Add a new coin to the UTXO set (simulates receiving)
-    pub fn add_coin(&mut self, coin: PrivateCoin, metadata: CoinMetadata) -> [u8; 32] {
-        let nullifier = coin.nullifier();
+    pub fn add_coin(
+        &mut self,
+        coin: PrivateCoin,
+        secrets: &clvm_zk_core::coin_commitment::CoinSecrets,
+        metadata: CoinMetadata,
+    ) -> [u8; 32] {
+        let nullifier = secrets.nullifier();
         let info = CoinInfo {
             coin: coin.clone(),
             metadata,
             created_at_height: self.block_height,
         };
 
+        let coin_commitment = CoinCommitment::compute(
+            coin.amount,
+            &coin.puzzle_hash,
+            &coin.serial_commitment,
+            crate::crypto_utils::hash_data_default,
+        );
+
+        let leaf_index = self.coin_tree.leaves_len();
+        self.coin_tree.insert(coin_commitment.0);
+        self.coin_tree.commit();
+        self.commitment_to_index
+            .insert(coin_commitment.0, leaf_index);
+
         self.utxo_set.insert(nullifier, info);
         nullifier
     }
 
-    /// Attempt to spend coins with explicit programs (simulates transaction submission)
     pub fn spend_coins(
         &mut self,
-        coin_programs: Vec<(PrivateCoin, String)>,
+        spends: Vec<(
+            PrivateCoin,
+            String,
+            clvm_zk_core::coin_commitment::CoinSecrets,
+        )>,
     ) -> Result<SimulatedTransaction, SimulatorError> {
-        // 1. Validate no double-spends
-        let mut new_nullifiers = Vec::new();
-        let mut coins = Vec::new();
-        for (coin, _program) in &coin_programs {
-            let nullifier = coin.nullifier();
-            if self.nullifier_set.contains(&nullifier) {
-                return Err(SimulatorError::DoubleSpend(hex::encode(nullifier)));
-            }
-            new_nullifiers.push(nullifier);
-            coins.push(coin.clone());
-        }
-
-        // 2. Generate spend bundles using test protocol with provided programs
-        let mut spend_bundles = Vec::new();
-        for (coin, program) in coin_programs {
-            // Let the Spender handle program validation - it has the proper hashing logic
-            match Spender::create_spend(&coin, &program, &[]) {
-                Ok(bundle) => spend_bundles.push(bundle),
-                Err(e) => return Err(SimulatorError::ProofGeneration(format!("{:?}", e))),
-            }
-        }
-
-        // 3. Create transaction
-        let tx = SimulatedTransaction {
-            id: self.generate_tx_id(),
-            spend_bundles,
-            nullifiers: new_nullifiers.clone(),
-            block_height: self.block_height,
-            timestamp: self.block_height * 10, // Mock timestamp
-        };
-
-        // 4. Update state
-        for nullifier in new_nullifiers {
-            self.nullifier_set.insert(nullifier);
-            self.utxo_set.remove(&nullifier);
-        }
-
-        self.transactions.push(tx.clone());
-        self.block_height += 1;
-
-        Ok(tx)
+        self.spend_coins_with_params(
+            spends
+                .into_iter()
+                .map(|(coin, program, secrets)| (coin, program, vec![], secrets))
+                .collect(),
+        )
     }
 
-    /// Spend coins with signature verification (enhanced security)
-    ///
-    /// This method requires valid ECDSA signatures for spending coins.
-    /// Each spend must provide a signature that verifies against the coin's puzzle program.
-    pub fn spend_coins_with_signatures(
+    pub fn spend_coins_with_params(
         &mut self,
-        spends: Vec<(PrivateCoin, String, Vec<u8>, Vec<u8>)>, // (coin, program, public_key, signature)
+        spends: Vec<(
+            PrivateCoin,
+            String,
+            Vec<crate::ProgramParameter>,
+            clvm_zk_core::coin_commitment::CoinSecrets,
+        )>,
     ) -> Result<SimulatedTransaction, SimulatorError> {
-        // 1. Validate no double-spends
         let mut new_nullifiers = Vec::new();
-        for (coin, _program, _public_key, _signature) in &spends {
-            let nullifier = coin.nullifier();
+        for (_, _, _, secrets) in &spends {
+            let nullifier = secrets.serial_number;
             if self.nullifier_set.contains(&nullifier) {
                 return Err(SimulatorError::DoubleSpend(hex::encode(nullifier)));
             }
             new_nullifiers.push(nullifier);
         }
 
-        // 2. Generate spend bundles with signature verification
+        let merkle_root = self.coin_tree.root().ok_or_else(|| {
+            SimulatorError::TestFailed("merkle tree has no root".to_string())
+        })?;
+        
         let mut spend_bundles = Vec::new();
-        for (coin, program, public_key_bytes, signature_bytes) in spends {
-            // Create spend message (standardized message for signature verification)
-            let spend_message = format!("authorize_spend_{}", hex::encode(coin.nullifier()));
+        for (coin, program, params, secrets) in spends {
+            let merkle_path = self.get_merkle_path(&coin).ok_or_else(|| {
+                SimulatorError::TestFailed("coin not found in merkle tree".to_string())
+            })?;
 
-            // Create program parameters including signature verification data
-            let params = create_signature_spend_params(
-                &public_key_bytes,
-                spend_message.as_bytes(),
-                &signature_bytes,
-            );
-
-            // Create spend bundle with signature verification
-            match Spender::create_spend(&coin, &program, &params) {
+            match Spender::create_spend_with_serial(&coin, &program, &params, &secrets, merkle_path, merkle_root) {
                 Ok(bundle) => spend_bundles.push(bundle),
                 Err(e) => return Err(SimulatorError::ProofGeneration(format!("{:?}", e))),
             }
         }
 
-        // 3. Create transaction
         let tx = SimulatedTransaction {
             id: self.generate_tx_id(),
             spend_bundles,
@@ -153,10 +125,9 @@ impl CLVMZkSimulator {
             timestamp: self.block_height * 10,
         };
 
-        // 4. Update state
-        for nullifier in new_nullifiers {
-            self.nullifier_set.insert(nullifier);
-            self.utxo_set.remove(&nullifier);
+        for nullifier in &new_nullifiers {
+            self.nullifier_set.insert(*nullifier);
+            self.utxo_set.remove(nullifier);
         }
 
         self.transactions.push(tx.clone());
@@ -165,22 +136,42 @@ impl CLVMZkSimulator {
         Ok(tx)
     }
 
-    /// Check if nullifier exists (double-spend check)
     pub fn has_nullifier(&self, nullifier: &[u8; 32]) -> bool {
         self.nullifier_set.contains(nullifier)
     }
 
-    /// Get coin info by nullifier
     pub fn get_coin_info(&self, nullifier: &[u8; 32]) -> Option<&CoinInfo> {
         self.utxo_set.get(nullifier)
     }
 
-    /// Get iterator over UTXO set for testing
+    pub fn get_merkle_path(&self, coin: &PrivateCoin) -> Option<Vec<[u8; 32]>> {
+        let coin_commitment = CoinCommitment::compute(
+            coin.amount,
+            &coin.puzzle_hash,
+            &coin.serial_commitment,
+            crate::crypto_utils::hash_data_default,
+        );
+
+        let leaf_index = *self.commitment_to_index.get(&coin_commitment.0)?;
+        let proof = self.coin_tree.proof(&[leaf_index]);
+        let proof_hashes = proof.proof_hashes();
+
+        Some(
+            proof_hashes
+                .iter()
+                .map(|hash| {
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(hash);
+                    arr
+                })
+                .collect(),
+        )
+    }
+
     pub fn utxo_iter(&self) -> impl Iterator<Item = (&[u8; 32], &CoinInfo)> {
         self.utxo_set.iter()
     }
 
-    /// Generate transaction ID
     fn generate_tx_id(&self) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(b"clvm_zk_tx_id");
@@ -189,7 +180,6 @@ impl CLVMZkSimulator {
         hasher.finalize().into()
     }
 
-    /// Get stats for analysis
     pub fn stats(&self) -> SimulatorStats {
         SimulatorStats {
             total_coins_created: self
@@ -204,20 +194,17 @@ impl CLVMZkSimulator {
         }
     }
 
-    /// Reset simulator state
     pub fn reset(&mut self) {
         self.nullifier_set.clear();
         self.utxo_set.clear();
+        self.coin_tree = MerkleTree::<MerkleHasher>::new();
+        self.commitment_to_index.clear();
         self.transactions.clear();
         self.block_height = 0;
     }
 }
 
-// ============================================================================
-// Data Structures
-// ============================================================================
-
-/// Information about a coin in the simulator
+/// coin info in simulator
 #[derive(Debug, Clone)]
 pub struct CoinInfo {
     pub coin: PrivateCoin,
@@ -225,7 +212,6 @@ pub struct CoinInfo {
     pub created_at_height: u64,
 }
 
-/// Metadata for testing scenarios
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoinMetadata {
     pub owner: String,
@@ -241,7 +227,6 @@ pub enum CoinType {
     Atomic,
 }
 
-/// Simulated transaction
 #[derive(Debug, Clone)]
 pub struct SimulatedTransaction {
     pub id: [u8; 32],
@@ -251,7 +236,6 @@ pub struct SimulatedTransaction {
     pub timestamp: u64,
 }
 
-/// Simulator statistics
 #[derive(Debug)]
 pub struct SimulatorStats {
     pub total_coins_created: usize,
@@ -260,10 +244,6 @@ pub struct SimulatorStats {
     pub current_utxo_count: usize,
     pub current_block_height: u64,
 }
-
-// ============================================================================
-// Error Types
-// ============================================================================
 
 #[derive(Debug, thiserror::Error)]
 pub enum SimulatorError {
@@ -278,10 +258,6 @@ pub enum SimulatorError {
     #[error("Protocol error: {0}")]
     Protocol(#[from] ProtocolError),
 }
-
-// ============================================================================
-// Display Implementations
-// ============================================================================
 
 impl fmt::Display for SimulatedTransaction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/testing_helpers.rs
+++ b/src/testing_helpers.rs
@@ -51,7 +51,12 @@ impl CoinFactory {
         users: &[&str],
         amounts: &[u64],
         puzzle_type: PuzzleType,
-    ) -> Vec<(String, PrivateCoin, [u8; 4], clvm_zk_core::coin_commitment::CoinSecrets)> {
+    ) -> Vec<(
+        String,
+        PrivateCoin,
+        [u8; 4],
+        clvm_zk_core::coin_commitment::CoinSecrets,
+    )> {
         users
             .iter()
             .zip(amounts.iter())
@@ -145,8 +150,6 @@ pub enum PuzzleType {
     Atomic,
 }
 
-
-
 // ============================================================================
 // Test Scenarios
 // ============================================================================
@@ -180,7 +183,11 @@ impl TestScenarios {
         );
 
         // First spend should succeed
-        let result1 = sim.spend_coins(vec![(coin.clone(), puzzle_program.clone(), secrets.clone())]);
+        let result1 = sim.spend_coins(vec![(
+            coin.clone(),
+            puzzle_program.clone(),
+            secrets.clone(),
+        )]);
         assert!(result1.is_ok(), "First spend should succeed");
 
         // Second spend should fail (double-spend)
@@ -250,7 +257,11 @@ impl TestScenarios {
 
         // Mix all coins in one transaction
         let (puzzle_program, _) = Self::create_test_puzzle_for_scenarios(1000);
-        let coins_to_spend: Vec<(PrivateCoin, String, clvm_zk_core::coin_commitment::CoinSecrets)> = user_coins
+        let coins_to_spend: Vec<(
+            PrivateCoin,
+            String,
+            clvm_zk_core::coin_commitment::CoinSecrets,
+        )> = user_coins
             .into_iter()
             .map(|(_, coin, _, secrets)| (coin, puzzle_program.clone(), secrets))
             .collect();

--- a/src/testing_helpers.rs
+++ b/src/testing_helpers.rs
@@ -211,10 +211,10 @@ impl TestScenarios {
         let (_coin1, secrets1) = CoinFactory::create_coin(spend_secret, PuzzleType::P2PK, 1000);
         let (_coin2, secrets2) = CoinFactory::create_coin(spend_secret, PuzzleType::Multisig, 1000);
 
-        let null1 = secrets1.nullifier();
-        let null2 = secrets2.nullifier();
+        let serial1 = secrets1.serial_number();
+        let serial2 = secrets2.serial_number();
 
-        if null1 == null2 {
+        if serial1 == serial2 {
             return Err(SimulatorError::TestFailed(
                 "cross-puzzle replay vulnerability".to_string(),
             ));
@@ -294,7 +294,7 @@ impl TestScenarios {
                 },
             );
 
-            coin_secrets_backup.push((secrets.nullifier(), secrets));
+            coin_secrets_backup.push((secrets.serial_number(), secrets));
         }
 
         println!(

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -72,7 +72,7 @@ impl CLVMHDWallet {
             hasher.update(spending_key);
             hasher.finalize().into()
         };
-        
+
         // Derive x25519 key for encrypted note decryption
         let note_encryption_private = {
             let mut hasher = Sha256::new();
@@ -80,7 +80,7 @@ impl CLVMHDWallet {
             hasher.update(account_bytes);
             hasher.finalize().into()
         };
-        
+
         // Compute x25519 public key
         let note_encryption_public = {
             use x25519_dalek::{PublicKey, StaticSecret};
@@ -117,8 +117,8 @@ pub struct AccountKeys {
     pub spending_key: [u8; 32],
     pub viewing_key: [u8; 32],
     pub nullifier_key: [u8; 32],
-    pub note_encryption_private: [u8; 32],  // x25519 private key for decrypting notes
-    pub note_encryption_public: [u8; 32],   // x25519 public key for receiving notes
+    pub note_encryption_private: [u8; 32], // x25519 private key for decrypting notes
+    pub note_encryption_public: [u8; 32],  // x25519 public key for receiving notes
     pub account_index: u32,
     pub network: crate::wallet::Network,
     _account_xprv: XPrv, // Keep for potential child derivation
@@ -168,12 +168,7 @@ pub struct WalletPrivateCoin {
 }
 
 impl WalletPrivateCoin {
-    pub fn new(
-        puzzle_hash: [u8; 32],
-        amount: u64,
-        account_index: u32,
-        coin_index: u32,
-    ) -> Self {
+    pub fn new(puzzle_hash: [u8; 32], amount: u64, account_index: u32, coin_index: u32) -> Self {
         let (coin, secrets) = crate::protocol::PrivateCoin::new_with_secrets(puzzle_hash, amount);
 
         Self {

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -185,7 +185,12 @@ impl WalletPrivateCoin {
 
     pub fn with_hint(&self) -> ([u8; 4], [u8; 32]) {
         let serial_number = self.serial_number();
-        let hint = [serial_number[0], serial_number[1], serial_number[2], serial_number[3]];
+        let hint = [
+            serial_number[0],
+            serial_number[1],
+            serial_number[2],
+            serial_number[3],
+        ];
         (hint, serial_number)
     }
 

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -1,19 +1,9 @@
-// ============================================================================
-// CLVM-ZK HD Wallet with Proper bip32 v0.5 API
-// Zcash-style key derivation with domain-separated nullifiers
-// ============================================================================
+// hd wallet with bip32 key derivation
 
 use bip32::{ChildNumber, XPrv, XPub};
-use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt;
-
-type HmacSha256 = Hmac<Sha256>;
-
-// ============================================================================
-// HD Wallet with bip32 v0.5
-// ============================================================================
 
 pub struct CLVMHDWallet {
     master: XPrv,
@@ -21,7 +11,6 @@ pub struct CLVMHDWallet {
 }
 
 impl CLVMHDWallet {
-    /// Create wallet from seed (16-64 bytes)
     pub fn from_seed(
         seed: &[u8],
         network: crate::wallet::Network,
@@ -30,13 +19,11 @@ impl CLVMHDWallet {
             return Err(crate::wallet::WalletError::InvalidSeed);
         }
 
-        // Convert seed to 32 bytes if needed
         let seed_32 = if seed.len() == 32 {
             let mut arr = [0u8; 32];
             arr.copy_from_slice(seed);
             arr
         } else {
-            // Hash to get exactly 32 bytes
             Sha256::digest(seed).into()
         };
 
@@ -45,7 +32,6 @@ impl CLVMHDWallet {
         Ok(Self { master, network })
     }
 
-    /// Derive a key from a BIP44 path by iterating through child derivations
     fn derive_path(&self, path: &[ChildNumber]) -> Result<XPrv, crate::wallet::WalletError> {
         let mut current_key = self.master.clone();
 
@@ -58,24 +44,20 @@ impl CLVMHDWallet {
         Ok(current_key)
     }
 
-    /// Derive account-level keys following BIP44
-    /// Path: m/44'/coin_type'/account'/0'
     pub fn derive_account(
         &self,
         account_index: u32,
     ) -> Result<AccountKeys, crate::wallet::WalletError> {
-        // Build BIP44 path
         let path = [
-            ChildNumber::new(44, true)?,                       // purpose (hardened)
-            ChildNumber::new(self.network.coin_type(), true)?, // coin type (hardened)
-            ChildNumber::new(account_index, true)?,            // account (hardened)
-            ChildNumber::new(0, true)?,                        // reserved (hardened)
+            ChildNumber::new(44, true)?,
+            ChildNumber::new(self.network.coin_type(), true)?,
+            ChildNumber::new(account_index, true)?,
+            ChildNumber::new(0, true)?,
         ];
 
         let account_xprv = self.derive_path(&path)?;
         let account_bytes = account_xprv.to_bytes();
 
-        // Derive spending key from account XPrv
         let spending_key = {
             let mut hasher = Sha256::new();
             hasher.update(b"clvm_zk_spend_auth_v1");
@@ -84,7 +66,6 @@ impl CLVMHDWallet {
             hasher.finalize().into()
         };
 
-        // Derive viewing key from spending key
         let viewing_key = {
             let mut hasher = Sha256::new();
             hasher.update(b"clvm_zk_view_key_v1");
@@ -92,7 +73,6 @@ impl CLVMHDWallet {
             hasher.finalize().into()
         };
 
-        // Derive nullifier key from spending key
         let nullifier_key = {
             let mut hasher = Sha256::new();
             hasher.update(b"clvm_zk_nullifier_key_v1");
@@ -110,59 +90,11 @@ impl CLVMHDWallet {
         })
     }
 
-    /// Derive spend_secret for a specific coin
-    /// This uses account keys, not direct BIP32 derivation
-    pub fn derive_spend_secret(
-        &self,
-        account_index: u32,
-        coin_index: u32,
-    ) -> Result<SpendSecret, crate::wallet::WalletError> {
-        let account = self.derive_account(account_index)?;
-
-        // Use HMAC to derive coin-specific spend_secret from account spending key
-        let mut mac = HmacSha256::new_from_slice(&account.spending_key)
-            .map_err(|_| crate::wallet::WalletError::CryptoError)?;
-        mac.update(b"coin_spend_secret");
-        mac.update(&coin_index.to_le_bytes());
-
-        let secret: [u8; 32] = mac.finalize().into_bytes().into();
-
-        Ok(SpendSecret {
-            secret,
-            account_index,
-            coin_index,
-        })
-    }
-
-    /// Create nullifier with domain separation and puzzle binding
-    pub fn create_nullifier(
-        &self,
-        account_index: u32,
-        coin_index: u32,
-        puzzle_hash: [u8; 32],
-    ) -> Result<WalletNullifier, crate::wallet::WalletError> {
-        let spend_secret = self.derive_spend_secret(account_index, coin_index)?;
-
-        // Domain-separated nullifier construction
-        let bytes = crate::crypto_utils::generate_nullifier(&spend_secret.secret, &puzzle_hash);
-
-        Ok(WalletNullifier {
-            bytes,
-            spend_secret: spend_secret.secret,
-            puzzle_hash,
-        })
-    }
-
-    /// Get extended public key for account (for view-only wallets)
     pub fn account_xpub(&self, account_index: u32) -> Result<XPub, crate::wallet::WalletError> {
         let account = self.derive_account(account_index)?;
         Ok(XPub::from(&account._account_xprv))
     }
 }
-
-// ============================================================================
-// Account Keys
-// ============================================================================
 
 pub struct AccountKeys {
     pub spending_key: [u8; 32],
@@ -174,30 +106,6 @@ pub struct AccountKeys {
 }
 
 impl AccountKeys {
-    /// Derive coin-specific keys within this account
-    pub fn derive_coin_keys(&self, coin_index: u32, puzzle_hash: [u8; 32]) -> CoinKeys {
-        // Derive spend_secret using HMAC
-        let mut mac = HmacSha256::new_from_slice(&self.spending_key).expect("Valid HMAC key");
-        mac.update(b"coin_spend_secret");
-        mac.update(&coin_index.to_le_bytes());
-        let spend_secret: [u8; 32] = mac.finalize().into_bytes().into();
-
-        // Create viewing tag (first 4 bytes of hash)
-        let viewing_tag = crate::crypto_utils::generate_viewing_tag(&self.viewing_key, coin_index);
-
-        // Create nullifier with domain separation
-        let nullifier = crate::crypto_utils::generate_nullifier(&spend_secret, &puzzle_hash);
-
-        CoinKeys {
-            spend_secret,
-            viewing_tag,
-            nullifier,
-            puzzle_hash,
-            coin_index,
-        }
-    }
-
-    /// Export viewing key for auditing
     pub fn export_viewing_key(&self) -> ViewingKey {
         ViewingKey {
             key: self.viewing_key,
@@ -206,45 +114,6 @@ impl AccountKeys {
         }
     }
 }
-
-// ============================================================================
-// Key Types
-// ============================================================================
-
-#[derive(Clone, Debug)]
-pub struct SpendSecret {
-    pub secret: [u8; 32],
-    pub account_index: u32,
-    pub coin_index: u32,
-}
-
-#[derive(Clone, Debug)]
-pub struct WalletNullifier {
-    pub bytes: [u8; 32],
-    pub spend_secret: [u8; 32],
-    pub puzzle_hash: [u8; 32],
-}
-
-impl WalletNullifier {
-    /// Verify nullifier was constructed correctly
-    pub fn verify(&self, spend_secret: &[u8; 32], puzzle_hash: &[u8; 32]) -> bool {
-        let expected = crate::crypto_utils::generate_nullifier(spend_secret, puzzle_hash);
-        self.bytes == expected
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct CoinKeys {
-    pub spend_secret: [u8; 32],
-    pub viewing_tag: [u8; 4],
-    pub nullifier: [u8; 32],
-    pub puzzle_hash: [u8; 32],
-    pub coin_index: u32,
-}
-
-// ============================================================================
-// View-Only Wallet
-// ============================================================================
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ViewingKey {
@@ -262,61 +131,50 @@ impl ViewOnlyWallet {
         Self { viewing_key }
     }
 
-    /// Derive viewing tag for coin discovery
     pub fn derive_viewing_tag(&self, coin_index: u32) -> [u8; 4] {
         crate::crypto_utils::generate_viewing_tag(&self.viewing_key.key, coin_index)
     }
 
-    /// Check if a viewing tag belongs to this wallet
     pub fn check_viewing_tag(&self, tag: &[u8; 4], max_index: u32) -> Option<u32> {
         crate::crypto_utils::find_coin_index_by_viewing_tag(tag, &self.viewing_key.key, max_index)
     }
 }
 
-// ============================================================================
-// Private Coin Integration
-// ============================================================================
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WalletPrivateCoin {
-    /// Core protocol coin data
     pub coin: crate::protocol::PrivateCoin,
-    /// Wallet-specific metadata
+    pub secrets: clvm_zk_core::coin_commitment::CoinSecrets,
     pub account_index: u32,
     pub coin_index: u32,
 }
 
 impl WalletPrivateCoin {
-    /// Create from HD wallet
-    pub fn from_wallet(
-        wallet: &CLVMHDWallet,
-        account_index: u32,
-        coin_index: u32,
+    pub fn new(
         puzzle_hash: [u8; 32],
         amount: u64,
-    ) -> Result<Self, crate::wallet::WalletError> {
-        let spend_secret = wallet.derive_spend_secret(account_index, coin_index)?;
+        account_index: u32,
+        coin_index: u32,
+    ) -> Self {
+        let (coin, secrets) = crate::protocol::PrivateCoin::new_with_secrets(puzzle_hash, amount);
 
-        Ok(Self {
-            coin: crate::protocol::PrivateCoin::new(spend_secret.secret, puzzle_hash, amount),
+        Self {
+            coin,
+            secrets,
             account_index,
             coin_index,
-        })
+        }
     }
 
-    /// Generate nullifier with domain separation
     pub fn nullifier(&self) -> [u8; 32] {
-        self.coin.nullifier()
+        self.secrets.nullifier()
     }
 
-    /// Create with recovery hint
     pub fn with_hint(&self) -> ([u8; 4], [u8; 32]) {
         let nullifier = self.nullifier();
         let hint = [nullifier[0], nullifier[1], nullifier[2], nullifier[3]];
         (hint, nullifier)
     }
 
-    /// Validate coin integrity
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.coin.validate().map_err(|e| match e {
             crate::protocol::ProtocolError::InvalidSpendSecret(_) => ValidationError::WeakSecret,
@@ -324,145 +182,21 @@ impl WalletPrivateCoin {
         })
     }
 
-    /// Get the spend secret (convenience method)
-    pub fn spend_secret(&self) -> [u8; 32] {
-        self.coin.spend_secret
-    }
+    // spend_secret removed - not part of serial commitment protocol
+    // nullifier comes from secrets.serial_number
 
-    /// Get the puzzle hash (convenience method)
     pub fn puzzle_hash(&self) -> [u8; 32] {
         self.coin.puzzle_hash
     }
 
-    /// Get the amount (convenience method)
     pub fn amount(&self) -> u64 {
         self.coin.amount
     }
 
-    /// Convert to protocol PrivateCoin
     pub fn to_protocol_coin(&self) -> crate::protocol::PrivateCoin {
         self.coin.clone()
     }
 }
-
-// ============================================================================
-// Wallet Recovery
-// ============================================================================
-
-pub struct WalletRecovery {
-    wallet: CLVMHDWallet,
-    gap_limit: u32,
-}
-
-impl WalletRecovery {
-    pub fn new(wallet: CLVMHDWallet) -> Self {
-        Self {
-            wallet,
-            gap_limit: 20, // BIP44 standard gap limit
-        }
-    }
-
-    /// Recover coins using viewing tags
-    pub fn recover_with_hints(
-        &self,
-        hints: &[[u8; 4]],
-        max_accounts: u32,
-        max_coins_per_account: u32,
-    ) -> Vec<RecoveredCoin> {
-        let mut recovered = Vec::new();
-
-        for account_idx in 0..max_accounts {
-            let account = match self.wallet.derive_account(account_idx) {
-                Ok(acc) => acc,
-                Err(_) => continue,
-            };
-
-            let mut gap_counter = 0;
-
-            for coin_idx in 0..max_coins_per_account {
-                // Derive viewing tag
-                let tag = crate::crypto_utils::generate_viewing_tag(&account.viewing_key, coin_idx);
-
-                if hints.contains(&tag) {
-                    let spend_secret = self
-                        .wallet
-                        .derive_spend_secret(account_idx, coin_idx)
-                        .expect("Valid derivation");
-
-                    recovered.push(RecoveredCoin {
-                        account_index: account_idx,
-                        coin_index: coin_idx,
-                        spend_secret: spend_secret.secret,
-                        viewing_tag: tag,
-                    });
-
-                    gap_counter = 0; // Reset gap counter
-                } else {
-                    gap_counter += 1;
-                    if gap_counter >= self.gap_limit {
-                        break; // Move to next account
-                    }
-                }
-            }
-        }
-
-        recovered
-    }
-
-    /// Scan blockchain for spent nullifiers
-    pub fn scan_nullifiers(
-        &self,
-        nullifiers: &[[u8; 32]],
-        puzzle_hashes: &[[u8; 32]],
-        max_accounts: u32,
-        max_coins_per_account: u32,
-    ) -> Vec<RecoveredSpend> {
-        let mut found = Vec::new();
-
-        for account_idx in 0..max_accounts {
-            for coin_idx in 0..max_coins_per_account {
-                // Check against all puzzle hashes
-                for &puzzle_hash in puzzle_hashes {
-                    let nullifier = self
-                        .wallet
-                        .create_nullifier(account_idx, coin_idx, puzzle_hash)
-                        .expect("Valid nullifier");
-
-                    if nullifiers.contains(&nullifier.bytes) {
-                        found.push(RecoveredSpend {
-                            account_index: account_idx,
-                            coin_index: coin_idx,
-                            nullifier: nullifier.bytes,
-                            puzzle_hash,
-                        });
-                    }
-                }
-            }
-        }
-
-        found
-    }
-}
-
-#[derive(Debug)]
-pub struct RecoveredCoin {
-    pub account_index: u32,
-    pub coin_index: u32,
-    pub spend_secret: [u8; 32],
-    pub viewing_tag: [u8; 4],
-}
-
-#[derive(Debug)]
-pub struct RecoveredSpend {
-    pub account_index: u32,
-    pub coin_index: u32,
-    pub nullifier: [u8; 32],
-    pub puzzle_hash: [u8; 32],
-}
-
-// ============================================================================
-// Error Types
-// ============================================================================
 
 #[derive(Debug, thiserror::Error)]
 pub enum ValidationError {
@@ -471,16 +205,6 @@ pub enum ValidationError {
 
     #[error("Invalid puzzle hash")]
     InvalidPuzzle,
-}
-
-// ============================================================================
-// Display Implementations
-// ============================================================================
-
-impl fmt::Display for WalletNullifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "null:{}", hex::encode(&self.bytes[0..8]))
-    }
 }
 
 impl fmt::Display for ViewingKey {

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -179,14 +179,14 @@ impl WalletPrivateCoin {
         }
     }
 
-    pub fn nullifier(&self) -> [u8; 32] {
-        self.secrets.nullifier()
+    pub fn serial_number(&self) -> [u8; 32] {
+        self.secrets.serial_number()
     }
 
     pub fn with_hint(&self) -> ([u8; 4], [u8; 32]) {
-        let nullifier = self.nullifier();
-        let hint = [nullifier[0], nullifier[1], nullifier[2], nullifier[3]];
-        (hint, nullifier)
+        let serial_number = self.serial_number();
+        let hint = [serial_number[0], serial_number[1], serial_number[2], serial_number[3]];
+        (hint, serial_number)
     }
 
     pub fn validate(&self) -> Result<(), ValidationError> {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -3,9 +3,5 @@ pub mod hd_wallet;
 pub mod tests;
 pub mod types;
 
-// Re-exports (specific to avoid ambiguity)
-pub use hd_wallet::{CLVMHDWallet, ValidationError, WalletPrivateCoin, WalletRecovery};
+pub use hd_wallet::{AccountKeys, CLVMHDWallet, ValidationError, ViewingKey, WalletPrivateCoin};
 pub use types::{Network, WalletError};
-
-// Use HD wallet versions as primary (more complete implementations)
-pub use hd_wallet::{AccountKeys, CoinKeys, SpendSecret, ViewingKey, WalletNullifier};

--- a/src/wallet/tests.rs
+++ b/src/wallet/tests.rs
@@ -85,7 +85,10 @@ mod tests {
 
         assert_eq!(wallet_coin.puzzle_hash(), protocol_coin.puzzle_hash);
         assert_eq!(wallet_coin.amount(), protocol_coin.amount);
-        assert_eq!(wallet_coin.serial_number(), wallet_coin.secrets.serial_number());
+        assert_eq!(
+            wallet_coin.serial_number(),
+            wallet_coin.secrets.serial_number()
+        );
     }
 
     #[test]

--- a/src/wallet/tests.rs
+++ b/src/wallet/tests.rs
@@ -1,34 +1,19 @@
-// ============================================================================
-// Comprehensive HD Wallet Tests
-// Tests ALL functionality: signing, recovery, viewing keys, spending keys
-// ============================================================================
-
 #[cfg(test)]
 mod tests {
     use super::super::*;
-    use crate::protocol::Spender;
     use crate::wallet::hd_wallet::*;
 
-    // Test seeds for deterministic testing
-    const TEST_SEED_MAINNET: &[u8] = b"test seed must be at least 16 bytes long for mainnet!!!";
-    const TEST_SEED_TESTNET: &[u8] = b"another test seed that is long enough for testnet!!!!";
-    const TEST_SEED_RECOVERY: &[u8] = b"recovery test seed with sufficient entropy content!!!!";
-
-    // ============================================================================
-    // Basic Wallet Creation Tests
-    // ============================================================================
+    const TEST_SEED: &[u8] = b"test seed must be at least 16 bytes long!!!";
 
     #[test]
     fn test_wallet_creation_from_seed() {
         // Test different seed lengths
         let short_seed = b"short";
         let result = CLVMHDWallet::from_seed(short_seed, Network::Testnet);
-        assert!(result.is_err(), "Should reject seeds shorter than 16 bytes");
+        assert!(result.is_err());
 
-        let good_seed = b"this is a perfectly fine seed with good entropy!!";
+        let good_seed = TEST_SEED;
         let wallet = CLVMHDWallet::from_seed(good_seed, Network::Mainnet).unwrap();
-
-        // Should derive account successfully
         let account = wallet.derive_account(0).unwrap();
         assert_eq!(account.account_index, 0);
         assert_eq!(account.network, Network::Mainnet);
@@ -36,9 +21,8 @@ mod tests {
 
     #[test]
     fn test_deterministic_key_derivation() {
-        // Same seed should produce same keys
-        let wallet1 = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-        let wallet2 = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
+        let wallet1 = CLVMHDWallet::from_seed(TEST_SEED, Network::Mainnet).unwrap();
+        let wallet2 = CLVMHDWallet::from_seed(TEST_SEED, Network::Mainnet).unwrap();
 
         let account1 = wallet1.derive_account(0).unwrap();
         let account2 = wallet2.derive_account(0).unwrap();
@@ -50,476 +34,98 @@ mod tests {
 
     #[test]
     fn test_different_networks_produce_different_keys() {
-        let wallet_mainnet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-        let wallet_testnet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Testnet).unwrap();
+        let wallet_mainnet = CLVMHDWallet::from_seed(TEST_SEED, Network::Mainnet).unwrap();
+        let wallet_testnet = CLVMHDWallet::from_seed(TEST_SEED, Network::Testnet).unwrap();
 
         let account_main = wallet_mainnet.derive_account(0).unwrap();
         let account_test = wallet_testnet.derive_account(0).unwrap();
 
-        // Same seed, different networks = different keys
         assert_ne!(account_main.spending_key, account_test.spending_key);
         assert_ne!(account_main.viewing_key, account_test.viewing_key);
     }
 
-    // ============================================================================
-    // Spend Secret and Nullifier Tests
-    // ============================================================================
-
     #[test]
-    fn test_spend_secret_derivation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-
-        // Different accounts should have different secrets
-        let secret_acc0_coin0 = wallet.derive_spend_secret(0, 0).unwrap();
-        let secret_acc1_coin0 = wallet.derive_spend_secret(1, 0).unwrap();
-        assert_ne!(secret_acc0_coin0.secret, secret_acc1_coin0.secret);
-
-        // Different coins should have different secrets
-        let secret_acc0_coin1 = wallet.derive_spend_secret(0, 1).unwrap();
-        assert_ne!(secret_acc0_coin0.secret, secret_acc0_coin1.secret);
-
-        // Same parameters should give same secret (deterministic)
-        let secret_duplicate = wallet.derive_spend_secret(0, 0).unwrap();
-        assert_eq!(secret_acc0_coin0.secret, secret_duplicate.secret);
-    }
-
-    #[test]
-    fn test_nullifier_domain_separation_and_puzzle_binding() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
-        let puzzle1 = [1u8; 32];
-        let puzzle2 = [2u8; 32];
-
-        // Same coin, different puzzles = different nullifiers (prevents cross-puzzle replay)
-        let null1 = wallet.create_nullifier(0, 0, puzzle1).unwrap();
-        let null2 = wallet.create_nullifier(0, 0, puzzle2).unwrap();
-        assert_ne!(null1.bytes, null2.bytes);
-
-        // Different coins, same puzzle = different nullifiers
-        let null3 = wallet.create_nullifier(0, 1, puzzle1).unwrap();
-        assert_ne!(null1.bytes, null3.bytes);
-
-        // Same parameters = same nullifier (deterministic)
-        let null4 = wallet.create_nullifier(0, 0, puzzle1).unwrap();
-        assert_eq!(null1.bytes, null4.bytes);
-
-        // Verify nullifier construction
-        assert!(null1.verify(&null1.spend_secret, &puzzle1));
-        assert!(!null1.verify(&null1.spend_secret, &puzzle2));
-    }
-
-    #[test]
-    fn test_nullifier_matches_protocol_implementation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-        let puzzle_hash = [42u8; 32];
-
-        // Create coin through wallet
-        let wallet_coin = WalletPrivateCoin::from_wallet(&wallet, 0, 0, puzzle_hash, 1000).unwrap();
-
-        // Create equivalent protocol coin
-        let protocol_coin = wallet_coin.to_protocol_coin();
-
-        // Nullifiers should match
-        assert_eq!(wallet_coin.nullifier(), protocol_coin.nullifier());
-
-        // Wallet's nullifier calculation should match coin's
-        let wallet_nullifier = wallet.create_nullifier(0, 0, puzzle_hash).unwrap();
-        assert_eq!(wallet_nullifier.bytes, wallet_coin.nullifier());
-    }
-
-    // ============================================================================
-    // Viewing Key Tests
-    // ============================================================================
-
-    #[test]
-    fn test_viewing_key_export_and_separation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
+    fn test_viewing_key_export() {
+        let wallet = CLVMHDWallet::from_seed(TEST_SEED, Network::Mainnet).unwrap();
         let account = wallet.derive_account(0).unwrap();
         let viewing_key = account.export_viewing_key();
 
-        // Create view-only wallet
         let view_wallet = ViewOnlyWallet::from_viewing_key(viewing_key.clone());
 
-        // Should derive same viewing tags
-        let tag1 = account.derive_coin_keys(5, [0; 32]).viewing_tag;
+        let tag1 = view_wallet.derive_viewing_tag(5);
         let tag2 = view_wallet.derive_viewing_tag(5);
         assert_eq!(tag1, tag2);
 
-        // Should be able to check viewing tags
         assert_eq!(view_wallet.check_viewing_tag(&tag1, 100), Some(5));
         assert_eq!(view_wallet.check_viewing_tag(&[0xFF; 4], 100), None);
     }
 
     #[test]
-    fn test_viewing_key_privacy_separation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-
-        let account = wallet.derive_account(0).unwrap();
-        let viewing_key = account.export_viewing_key();
-        let view_wallet = ViewOnlyWallet::from_viewing_key(viewing_key);
-
-        // View-only wallet can derive viewing tags but NOT spend secrets
-        let viewing_tag = view_wallet.derive_viewing_tag(10);
-        assert_eq!(viewing_tag.len(), 4);
-
-        // Compare with full account's tag derivation
-        let coin_keys = account.derive_coin_keys(10, [0; 32]);
-        assert_eq!(viewing_tag, coin_keys.viewing_tag);
-
-        // But view-only wallet cannot derive spending keys
-        // (This is ensured by not exposing spending_key in ViewOnlyWallet)
-    }
-
-    // ============================================================================
-    // Account and Coin Key Tests
-    // ============================================================================
-
-    #[test]
-    fn test_account_key_derivation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
-        // Different accounts should have different keys
-        let account0 = wallet.derive_account(0).unwrap();
-        let account1 = wallet.derive_account(1).unwrap();
-
-        assert_ne!(account0.spending_key, account1.spending_key);
-        assert_ne!(account0.viewing_key, account1.viewing_key);
-        assert_ne!(account0.nullifier_key, account1.nullifier_key);
-
-        // Account indices should be correct
-        assert_eq!(account0.account_index, 0);
-        assert_eq!(account1.account_index, 1);
-    }
-
-    #[test]
-    fn test_coin_key_derivation_within_account() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-        let account = wallet.derive_account(0).unwrap();
-
-        let puzzle_hash = [123u8; 32];
-
-        // Different coin indices should produce different keys
-        let coin0 = account.derive_coin_keys(0, puzzle_hash);
-        let coin1 = account.derive_coin_keys(1, puzzle_hash);
-
-        assert_ne!(coin0.spend_secret, coin1.spend_secret);
-        assert_ne!(coin0.viewing_tag, coin1.viewing_tag);
-        assert_ne!(coin0.nullifier, coin1.nullifier);
-
-        // Same puzzle hash should be preserved
-        assert_eq!(coin0.puzzle_hash, puzzle_hash);
-        assert_eq!(coin1.puzzle_hash, puzzle_hash);
-
-        // Coin indices should be correct
-        assert_eq!(coin0.coin_index, 0);
-        assert_eq!(coin1.coin_index, 1);
-    }
-
-    // ============================================================================
-    // Private Coin Integration Tests
-    // ============================================================================
-
-    #[test]
-    fn test_private_coin_creation_and_validation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
+    fn test_private_coin_creation_with_random_serials() {
         let puzzle_hash = [42u8; 32];
-        let coin = WalletPrivateCoin::from_wallet(&wallet, 0, 0, puzzle_hash, 1000).unwrap();
+        let coin1 = WalletPrivateCoin::new(puzzle_hash, 1000, 0, 0);
+        let coin2 = WalletPrivateCoin::new(puzzle_hash, 1000, 0, 0);
 
-        // Should validate successfully
-        coin.validate().unwrap();
+        // should validate successfully
+        coin1.validate().unwrap();
+        coin2.validate().unwrap();
 
-        // Should generate consistent nullifier
-        let null1 = coin.nullifier();
-        let null2 = coin.nullifier();
-        assert_eq!(null1, null2);
+        assert_ne!(coin1.nullifier(), coin2.nullifier());
 
-        // Should create hint correctly
-        let (hint, nullifier) = coin.with_hint();
-        assert_eq!(
-            hint,
-            [nullifier[0], nullifier[1], nullifier[2], nullifier[3]]
-        );
-
-        // Account and coin indices should be preserved
-        assert_eq!(coin.account_index, 0);
-        assert_eq!(coin.coin_index, 0);
-        assert_eq!(coin.amount(), 1000);
+        assert_eq!(coin1.account_index, 0);
+        assert_eq!(coin1.coin_index, 0);
+        assert_eq!(coin1.amount(), 1000);
     }
 
     #[test]
     fn test_private_coin_protocol_integration() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
         let puzzle_hash = [55u8; 32];
-
-        let wallet_coin = WalletPrivateCoin::from_wallet(&wallet, 1, 5, puzzle_hash, 2000).unwrap();
+        let wallet_coin = WalletPrivateCoin::new(puzzle_hash, 2000, 1, 5);
         let protocol_coin = wallet_coin.to_protocol_coin();
 
-        // Should preserve all essential data
-        assert_eq!(wallet_coin.spend_secret(), protocol_coin.spend_secret);
         assert_eq!(wallet_coin.puzzle_hash(), protocol_coin.puzzle_hash);
         assert_eq!(wallet_coin.amount(), protocol_coin.amount);
-        assert_eq!(wallet_coin.nullifier(), protocol_coin.nullifier());
-    }
-
-    // ============================================================================
-    // Wallet Recovery Tests
-    // ============================================================================
-
-    #[test]
-    fn test_wallet_recovery_with_hints() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_RECOVERY, Network::Mainnet).unwrap();
-        let account = wallet.derive_account(0).unwrap();
-
-        // Create viewing tags (not nullifier hints!)
-        let mut hints = Vec::new();
-        let mut expected_coins = Vec::new();
-
-        for i in 0..5 {
-            let coin = WalletPrivateCoin::from_wallet(&wallet, 0, i, [0; 32], 1000).unwrap();
-            let viewing_tag = crate::crypto_utils::generate_viewing_tag(&account.viewing_key, i);
-            hints.push(viewing_tag);
-            expected_coins.push((0u32, i, coin.spend_secret()));
-        }
-
-        // Simulate losing wallet and recovering from seed
-        let new_wallet = CLVMHDWallet::from_seed(TEST_SEED_RECOVERY, Network::Mainnet).unwrap();
-        let recovery = WalletRecovery::new(new_wallet);
-
-        // Should recover all coins
-        let recovered = recovery.recover_with_hints(&hints, 1, 100);
-        assert_eq!(recovered.len(), 5);
-
-        // Check that all expected coins were recovered
-        for (expected_account, expected_coin, expected_secret) in expected_coins {
-            let found = recovered
-                .iter()
-                .find(|r| r.account_index == expected_account && r.coin_index == expected_coin);
-
-            assert!(
-                found.is_some(),
-                "Failed to recover coin {}/{}",
-                expected_account,
-                expected_coin
-            );
-            let recovered_coin = found.unwrap();
-            assert_eq!(recovered_coin.spend_secret, expected_secret);
-        }
-    }
-
-    #[test]
-    fn test_wallet_recovery_gap_limit() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_RECOVERY, Network::Testnet).unwrap();
-        let account = wallet.derive_account(0).unwrap();
-
-        // Create viewing tags for coins with gaps (don't need actual coins)
-        let hint0 = crate::crypto_utils::generate_viewing_tag(&account.viewing_key, 0);
-        let hint25 = crate::crypto_utils::generate_viewing_tag(&account.viewing_key, 25);
-        let hints = vec![hint0, hint25];
-
-        let recovery = WalletRecovery::new(wallet);
-        let recovered = recovery.recover_with_hints(&hints, 1, 100);
-
-        // Should only recover coin 0 due to gap limit
-        assert_eq!(recovered.len(), 1);
-        assert_eq!(recovered[0].coin_index, 0);
-    }
-
-    #[test]
-    fn test_nullifier_scanning_recovery() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
-        // Create some spent coins (simulate blockchain state)
-        let puzzle_hashes = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
-        let mut spent_nullifiers = Vec::new();
-
-        // Account 0, coins 0-2 with different puzzles
-        for (coin_idx, &puzzle_hash) in puzzle_hashes.iter().enumerate() {
-            let nullifier = wallet
-                .create_nullifier(0, coin_idx as u32, puzzle_hash)
-                .unwrap();
-            spent_nullifiers.push(nullifier.bytes);
-        }
-
-        let recovery = WalletRecovery::new(wallet);
-        let found = recovery.scan_nullifiers(&spent_nullifiers, &puzzle_hashes, 1, 10);
-
-        // Should find all 3 spent coins
-        assert_eq!(found.len(), 3);
-
-        for (i, recovered_spend) in found.iter().enumerate() {
-            assert_eq!(recovered_spend.account_index, 0);
-            assert_eq!(recovered_spend.coin_index, i as u32);
-            assert_eq!(recovered_spend.puzzle_hash, puzzle_hashes[i]);
-        }
-    }
-
-    // ============================================================================
-    // Cross-Protocol Integration Tests
-    // ============================================================================
-
-    #[test]
-    fn test_wallet_with_protocol_spender() {
-        // Skip if RISC0 proof generation is disabled
-        if std::env::var("RISC0_SKIP_BUILD").is_ok() {
-            return;
-        }
-
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-        let puzzle_hash = [77u8; 32];
-
-        let wallet_coin = WalletPrivateCoin::from_wallet(&wallet, 0, 0, puzzle_hash, 1500).unwrap();
-        let protocol_coin = wallet_coin.to_protocol_coin();
-
-        // Should be able to spend through protocol
-        let puzzle_code = "1500";
-        let result = Spender::create_spend(&protocol_coin, puzzle_code, &[]);
-
-        // Note: This might fail if puzzle_code doesn't match puzzle_hash exactly
-        // In real usage, the puzzle_code would need to hash to the expected puzzle_hash
-        match result {
-            Ok(spend_bundle) => {
-                assert_eq!(spend_bundle.nullifier, protocol_coin.nullifier());
-            }
-            Err(_) => {
-                // Expected if puzzle hash doesn't match - that's a security feature!
-                println!("Spend failed due to puzzle hash mismatch - this is expected");
-            }
-        }
-    }
-
-    // ============================================================================
-    // Edge Cases and Security Tests
-    // ============================================================================
-
-    #[test]
-    fn test_invalid_coin_validation() {
-        let _wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
-        // Create coin with all-zero spend secret (should be invalid)
-        let invalid_protocol_coin = crate::protocol::PrivateCoin::new([0u8; 32], [1; 32], 1000);
-        let invalid_coin = WalletPrivateCoin {
-            coin: invalid_protocol_coin,
-            account_index: 0,
-            coin_index: 0,
-        };
-
-        assert!(invalid_coin.validate().is_err());
-
-        // Create coin with all-zero puzzle hash (should be invalid)
-        let invalid_protocol_coin2 = crate::protocol::PrivateCoin::new([1; 32], [0u8; 32], 1000);
-        let invalid_coin2 = WalletPrivateCoin {
-            coin: invalid_protocol_coin2,
-            account_index: 0,
-            coin_index: 0,
-        };
-
-        assert!(invalid_coin2.validate().is_err());
-    }
-
-    #[test]
-    fn test_nullifier_uniqueness_across_all_parameters() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-
-        let mut nullifiers = std::collections::HashSet::new();
-
-        // Generate nullifiers for many different combinations
-        for account in 0..3 {
-            for coin in 0..10 {
-                for puzzle_variant in 0..5 {
-                    let puzzle_hash = [puzzle_variant; 32];
-                    let nullifier = wallet.create_nullifier(account, coin, puzzle_hash).unwrap();
-
-                    // Each nullifier should be unique
-                    assert!(
-                        nullifiers.insert(nullifier.bytes),
-                        "Duplicate nullifier found for account={}, coin={}, puzzle={}",
-                        account,
-                        coin,
-                        puzzle_variant
-                    );
-                }
-            }
-        }
-
-        // Should have generated 3 * 10 * 5 = 150 unique nullifiers
-        assert_eq!(nullifiers.len(), 150);
-    }
-
-    #[test]
-    fn test_seed_sensitivity() {
-        let seed1 = b"seed with one specific content for testing!";
-        let seed2 = b"seed with two specific content for testing!";
-
-        let wallet1 = CLVMHDWallet::from_seed(seed1, Network::Mainnet).unwrap();
-        let wallet2 = CLVMHDWallet::from_seed(seed2, Network::Mainnet).unwrap();
-
-        // Even tiny seed differences should produce completely different keys
-        let account1 = wallet1.derive_account(0).unwrap();
-        let account2 = wallet2.derive_account(0).unwrap();
-
-        assert_ne!(account1.spending_key, account2.spending_key);
-        assert_ne!(account1.viewing_key, account2.viewing_key);
-        assert_ne!(account1.nullifier_key, account2.nullifier_key);
-    }
-
-    // ============================================================================
-    // Performance and Stress Tests
-    // ============================================================================
-
-    #[test]
-    fn test_large_scale_key_derivation() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
-
-        // Should be able to derive many keys efficiently
-        for account in 0..10 {
-            let account_keys = wallet.derive_account(account).unwrap();
-
-            for coin in 0..100 {
-                let coin_keys = account_keys.derive_coin_keys(coin, [account as u8; 32]);
-
-                // Basic sanity checks
-                assert_ne!(coin_keys.spend_secret, [0u8; 32]);
-                assert_ne!(coin_keys.nullifier, [0u8; 32]);
-                assert_eq!(coin_keys.coin_index, coin);
-            }
-        }
-    }
-
-    // ============================================================================
-    // Display and Serialization Tests
-    // ============================================================================
-
-    #[test]
-    fn test_display_implementations() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_TESTNET, Network::Testnet).unwrap();
-        let account = wallet.derive_account(0).unwrap();
-
-        let nullifier = wallet.create_nullifier(0, 0, [1; 32]).unwrap();
-        let viewing_key = account.export_viewing_key();
-
-        // Should have meaningful string representations
-        let null_str = format!("{}", nullifier);
-        let view_str = format!("{}", viewing_key);
-
-        assert!(null_str.starts_with("null:"));
-        assert!(view_str.starts_with("vk:"));
-        assert!(view_str.contains("acc_0"));
+        assert_eq!(wallet_coin.nullifier(), wallet_coin.secrets.nullifier());
     }
 
     #[test]
     fn test_viewing_key_serialization() {
-        let wallet = CLVMHDWallet::from_seed(TEST_SEED_MAINNET, Network::Mainnet).unwrap();
+        let wallet = CLVMHDWallet::from_seed(TEST_SEED, Network::Mainnet).unwrap();
         let account = wallet.derive_account(0).unwrap();
         let viewing_key = account.export_viewing_key();
 
-        // Should be serializable and deserializable
+        // should be serializable
         let serialized = serde_json::to_string(&viewing_key).unwrap();
         let deserialized: ViewingKey = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(viewing_key.key, deserialized.key);
         assert_eq!(viewing_key.account_index, deserialized.account_index);
         assert_eq!(viewing_key.network, deserialized.network);
+    }
+
+    #[test]
+    fn test_wallet_coin_serialization() {
+        let puzzle_hash = [77u8; 32];
+        let coin = WalletPrivateCoin::new(puzzle_hash, 5000, 2, 10);
+
+        // should be serializable
+        let serialized = serde_json::to_string(&coin).unwrap();
+        let deserialized: WalletPrivateCoin = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(coin.nullifier(), deserialized.nullifier());
+        assert_eq!(coin.amount(), deserialized.amount());
+        assert_eq!(coin.account_index, deserialized.account_index);
+        assert_eq!(coin.coin_index, deserialized.coin_index);
+    }
+
+    #[test]
+    fn test_viewing_key_display() {
+        let wallet = CLVMHDWallet::from_seed(TEST_SEED, Network::Testnet).unwrap();
+        let account = wallet.derive_account(0).unwrap();
+        let viewing_key = account.export_viewing_key();
+
+        let view_str = format!("{}", viewing_key);
+        assert!(view_str.starts_with("vk:"));
+        assert!(view_str.contains("acc_0"));
     }
 }

--- a/src/wallet/tests.rs
+++ b/src/wallet/tests.rs
@@ -70,7 +70,7 @@ mod tests {
         coin1.validate().unwrap();
         coin2.validate().unwrap();
 
-        assert_ne!(coin1.nullifier(), coin2.nullifier());
+        assert_ne!(coin1.serial_number(), coin2.serial_number());
 
         assert_eq!(coin1.account_index, 0);
         assert_eq!(coin1.coin_index, 0);
@@ -85,7 +85,7 @@ mod tests {
 
         assert_eq!(wallet_coin.puzzle_hash(), protocol_coin.puzzle_hash);
         assert_eq!(wallet_coin.amount(), protocol_coin.amount);
-        assert_eq!(wallet_coin.nullifier(), wallet_coin.secrets.nullifier());
+        assert_eq!(wallet_coin.serial_number(), wallet_coin.secrets.serial_number());
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
         let serialized = serde_json::to_string(&coin).unwrap();
         let deserialized: WalletPrivateCoin = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(coin.nullifier(), deserialized.nullifier());
+        assert_eq!(coin.serial_number(), deserialized.serial_number());
         assert_eq!(coin.amount(), deserialized.amount());
         assert_eq!(coin.account_index, deserialized.account_index);
         assert_eq!(coin.coin_index, deserialized.coin_index);

--- a/tests/signature_integration_tests.rs
+++ b/tests/signature_integration_tests.rs
@@ -93,7 +93,10 @@ fn test_signature_enabled_spending() {
         CoinFactory::create_signature_coin_setup(spend_secret, amount);
 
     println!("   Created signature-enabled coin:");
-    println!("      - Serial number: {}", hex::encode(secrets.serial_number()));
+    println!(
+        "      - Serial number: {}",
+        hex::encode(secrets.serial_number())
+    );
     println!("      - Amount: {}", coin.amount);
     println!("      - Puzzle requires ECDSA signature");
 

--- a/tests/signature_integration_tests.rs
+++ b/tests/signature_integration_tests.rs
@@ -275,8 +275,26 @@ fn test_multiple_signature_coins_in_transaction() {
     println!("   💸 Spending multiple signature coins...");
     use clvm_zk::ProgramParameter;
     let result = sim.spend_coins_with_params(vec![
-        (coin1.clone(), program1, vec![ProgramParameter::Bytes(pubkey1), ProgramParameter::Bytes(spend_message.to_vec()), ProgramParameter::Bytes(sig1)], secrets1.clone()),
-        (coin2.clone(), program2, vec![ProgramParameter::Bytes(pubkey2), ProgramParameter::Bytes(spend_message.to_vec()), ProgramParameter::Bytes(sig2)], secrets2.clone()),
+        (
+            coin1.clone(),
+            program1,
+            vec![
+                ProgramParameter::Bytes(pubkey1),
+                ProgramParameter::Bytes(spend_message.to_vec()),
+                ProgramParameter::Bytes(sig1),
+            ],
+            secrets1.clone(),
+        ),
+        (
+            coin2.clone(),
+            program2,
+            vec![
+                ProgramParameter::Bytes(pubkey2),
+                ProgramParameter::Bytes(spend_message.to_vec()),
+                ProgramParameter::Bytes(sig2),
+            ],
+            secrets2.clone(),
+        ),
     ]);
 
     match result {

--- a/tests/simulator_tests.rs
+++ b/tests/simulator_tests.rs
@@ -53,7 +53,10 @@ fn test_basic_coin_creation_and_nullifiers() {
         "alice coin nullifier: {}",
         hex::encode(alice_secrets.nullifier())
     );
-    println!("bob coin nullifier: {}", hex::encode(bob_secrets.nullifier()));
+    println!(
+        "bob coin nullifier: {}",
+        hex::encode(bob_secrets.nullifier())
+    );
 
     assert_ne!(alice_secrets.nullifier(), bob_secrets.nullifier());
 
@@ -104,7 +107,11 @@ fn test_double_spend_prevention() {
     );
 
     println!("attempting first spend...");
-    let result1 = sim.spend_coins(vec![(coin.clone(), puzzle_program.clone(), secrets.clone())]);
+    let result1 = sim.spend_coins(vec![(
+        coin.clone(),
+        puzzle_program.clone(),
+        secrets.clone(),
+    )]);
 
     match result1 {
         Ok(tx) => {
@@ -166,7 +173,11 @@ fn test_multi_user_privacy_mixing() {
             },
         );
 
-        println!("{} coin nullifier: {}", user, hex::encode(secrets.nullifier()));
+        println!(
+            "{} coin nullifier: {}",
+            user,
+            hex::encode(secrets.nullifier())
+        );
         coin_programs.push((coin, puzzle_program.clone(), secrets));
     }
 
@@ -244,8 +255,16 @@ fn test_simulator_state_tracking() {
     assert_eq!(stats.total_transactions, 0);
 
     let spend_result = sim.spend_coins(vec![
-        (created_coins[0].clone(), puzzle_program.clone(), created_secrets[0].clone()),
-        (created_coins[1].clone(), puzzle_program.clone(), created_secrets[1].clone()),
+        (
+            created_coins[0].clone(),
+            puzzle_program.clone(),
+            created_secrets[0].clone(),
+        ),
+        (
+            created_coins[1].clone(),
+            puzzle_program.clone(),
+            created_secrets[1].clone(),
+        ),
     ]);
 
     match spend_result {

--- a/tests/simulator_tests.rs
+++ b/tests/simulator_tests.rs
@@ -7,22 +7,35 @@ use clvm_zk::protocol::PrivateCoin;
 use clvm_zk::simulator::*;
 use clvm_zk_core::chialisp::compile_chialisp_template_hash_default;
 
+use clvm_zk_core::coin_commitment::SerialCommitment;
 use sha2::{Digest, Sha256};
-/// Convert string to deterministic 32-byte spend secret
-fn string_to_spend_secret(s: &str) -> [u8; 32] {
-    Sha256::digest(format!("spend_secret_{}", s).as_bytes()).into()
-}
 
 /// Convert string to deterministic 32-byte puzzle hash
 fn string_to_puzzle_hash(s: &str) -> [u8; 32] {
     Sha256::digest(format!("puzzle_{}", s).as_bytes()).into()
 }
 
-/// Create a simple puzzle program and return both program and its hash
-/// This creates a program that will be consistent with how the CLVM system hashes it
+/// deterministic serial commitment for testing
+fn test_serial_commitment() -> SerialCommitment {
+    let serial_number = [1u8; 32];
+    let serial_randomness = [2u8; 32];
+    SerialCommitment::compute(
+        &serial_number,
+        &serial_randomness,
+        clvm_zk::crypto_utils::hash_data_default,
+    )
+}
+
+/// deterministic coin secrets for testing
+fn test_coin_secrets() -> clvm_zk_core::coin_commitment::CoinSecrets {
+    let serial_number = [1u8; 32];
+    let serial_randomness = [2u8; 32];
+    clvm_zk_core::coin_commitment::CoinSecrets::new(serial_number, serial_randomness)
+}
+
+/// create test puzzle program with matching hash
 fn create_test_puzzle(puzzle_id: &str) -> (String, [u8; 32]) {
     let program = format!("{}", puzzle_id);
-    // Calculate hash the same way the CLVM system does
     let hash = compile_chialisp_template_hash_default(&program).unwrap();
     (program, hash)
 }
@@ -31,140 +44,97 @@ fn create_test_puzzle(puzzle_id: &str) -> (String, [u8; 32]) {
 fn test_basic_coin_creation_and_nullifiers() {
     let mut sim = CLVMZkSimulator::new();
 
-    // Create coins with user-friendly identifiers
-    let alice_secret = string_to_spend_secret("alice_coin_1");
-    let bob_secret = string_to_spend_secret("bob_coin_1");
     let puzzle_hash = string_to_puzzle_hash("simple_p2pk");
 
-    let alice_coin = PrivateCoin::new(alice_secret, puzzle_hash, 1000);
-    let bob_coin = PrivateCoin::new(bob_secret, puzzle_hash, 2000);
+    let (alice_coin, alice_secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
+    let (bob_coin, bob_secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 2000);
 
     println!(
-        "Alice coin nullifier: {}",
-        hex::encode(alice_coin.nullifier())
+        "alice coin nullifier: {}",
+        hex::encode(alice_secrets.nullifier())
     );
-    println!("Bob coin nullifier: {}", hex::encode(bob_coin.nullifier()));
+    println!("bob coin nullifier: {}", hex::encode(bob_secrets.nullifier()));
 
-    // Different secrets should produce different nullifiers
-    assert_ne!(alice_coin.nullifier(), bob_coin.nullifier());
+    assert_ne!(alice_secrets.nullifier(), bob_secrets.nullifier());
 
-    // Same coin should produce same nullifier (deterministic)
-    let alice_coin_duplicate = PrivateCoin::new(alice_secret, puzzle_hash, 1000);
-    assert_eq!(alice_coin.nullifier(), alice_coin_duplicate.nullifier());
-
-    // Add coins to simulator
     let alice_nullifier = sim.add_coin(
         alice_coin.clone(),
+        &alice_secrets,
         CoinMetadata {
             owner: "alice".to_string(),
             coin_type: CoinType::Regular,
-            notes: "Alice's first coin".to_string(),
+            notes: "alice's first coin".to_string(),
         },
     );
 
     let bob_nullifier = sim.add_coin(
         bob_coin.clone(),
+        &bob_secrets,
         CoinMetadata {
             owner: "bob".to_string(),
             coin_type: CoinType::Regular,
-            notes: "Bob's first coin".to_string(),
+            notes: "bob's first coin".to_string(),
         },
     );
 
-    // Nullifiers should match coin calculations
-    assert_eq!(alice_nullifier, alice_coin.nullifier());
-    assert_eq!(bob_nullifier, bob_coin.nullifier());
+    assert_eq!(alice_nullifier, alice_secrets.nullifier());
+    assert_eq!(bob_nullifier, bob_secrets.nullifier());
 
-    // Simulator should track coins correctly
     assert!(sim.get_coin_info(&alice_nullifier).is_some());
     assert!(sim.get_coin_info(&bob_nullifier).is_some());
-    assert!(!sim.has_nullifier(&alice_nullifier)); // Not spent yet
-    assert!(!sim.has_nullifier(&bob_nullifier)); // Not spent yet
-}
-
-#[test]
-fn test_cross_puzzle_nullifier_separation() {
-    // Test that same spend secret produces different nullifiers for different puzzles
-    let spend_secret = string_to_spend_secret("shared_secret");
-    let puzzle_p2pk = string_to_puzzle_hash("p2pk_puzzle");
-    let puzzle_multisig = string_to_puzzle_hash("multisig_puzzle");
-    let puzzle_timelock = string_to_puzzle_hash("timelock_puzzle");
-
-    let coin_p2pk = PrivateCoin::new(spend_secret, puzzle_p2pk, 1000);
-    let coin_multisig = PrivateCoin::new(spend_secret, puzzle_multisig, 1000);
-    let coin_timelock = PrivateCoin::new(spend_secret, puzzle_timelock, 1000);
-
-    let null_p2pk = coin_p2pk.nullifier();
-    let null_multisig = coin_multisig.nullifier();
-    let null_timelock = coin_timelock.nullifier();
-
-    println!("P2PK nullifier: {}", hex::encode(null_p2pk));
-    println!("Multisig nullifier: {}", hex::encode(null_multisig));
-    println!("Timelock nullifier: {}", hex::encode(null_timelock));
-
-    // All should be different (prevents cross-puzzle replay attacks)
-    assert_ne!(null_p2pk, null_multisig);
-    assert_ne!(null_p2pk, null_timelock);
-    assert_ne!(null_multisig, null_timelock);
-
-    println!("Cross-puzzle nullifier separation verified");
+    assert!(!sim.has_nullifier(&alice_nullifier));
+    assert!(!sim.has_nullifier(&bob_nullifier));
 }
 
 #[test]
 fn test_double_spend_prevention() {
     let mut sim = CLVMZkSimulator::new();
 
-    // Create a coin with matching puzzle program and hash
-    let spend_secret = string_to_spend_secret("double_spend_test");
     let (puzzle_program, puzzle_hash) = create_test_puzzle("5000");
-    let coin = PrivateCoin::new(spend_secret, puzzle_hash, 5000);
+    let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 5000);
 
-    // Add to simulator
     sim.add_coin(
         coin.clone(),
+        &secrets,
         CoinMetadata {
             owner: "alice".to_string(),
             coin_type: CoinType::Regular,
-            notes: "Test coin for double spend".to_string(),
+            notes: "test coin for double spend".to_string(),
         },
     );
 
-    println!("Attempting first spend...");
-    // First spend should succeed
-    let result1 = sim.spend_coins(vec![(coin.clone(), puzzle_program.clone())]);
+    println!("attempting first spend...");
+    let result1 = sim.spend_coins(vec![(coin.clone(), puzzle_program.clone(), secrets.clone())]);
 
     match result1 {
         Ok(tx) => {
-            println!("First spend succeeded: {}", tx);
+            println!("first spend succeeded: {}", tx);
             assert_eq!(tx.nullifiers.len(), 1);
-            assert_eq!(tx.nullifiers[0], coin.nullifier());
-
-            // Nullifier should now be in the spent set
-            assert!(sim.has_nullifier(&coin.nullifier()));
+            assert_eq!(tx.nullifiers[0], secrets.nullifier());
+            assert!(sim.has_nullifier(&secrets.nullifier()));
         }
         Err(e) => {
-            println!("First spend failed: {:?}", e);
-            panic!("First spend should succeed");
+            println!("first spend failed: {:?}", e);
+            panic!("first spend should succeed");
         }
     }
 
-    println!("Attempting second spend (should fail)...");
-    // Second spend should fail due to double-spend
-    let result2 = sim.spend_coins(vec![(coin.clone(), puzzle_program)]);
+    println!("attempting second spend (should fail)...");
+    let result2 = sim.spend_coins(vec![(coin.clone(), puzzle_program, secrets.clone())]);
 
     match result2 {
         Ok(_) => {
-            panic!("Second spend should have failed (double-spend)");
+            panic!("second spend should have failed (double-spend)");
         }
         Err(SimulatorError::DoubleSpend(nullifier_hex)) => {
-            println!("Double-spend correctly prevented: {}", nullifier_hex);
+            println!("double-spend correctly prevented: {}", nullifier_hex);
             assert_eq!(
                 hex::decode(nullifier_hex).unwrap(),
-                coin.nullifier().to_vec()
+                secrets.nullifier().to_vec()
             );
         }
         Err(e) => {
-            panic!("Unexpected error: {:?}", e);
+            panic!("unexpected error: {:?}", e);
         }
     }
 }
@@ -173,7 +143,6 @@ fn test_double_spend_prevention() {
 fn test_multi_user_privacy_mixing() {
     let mut sim = CLVMZkSimulator::new();
 
-    // Create coins for multiple users
     let users = vec![
         ("alice", 1000),
         ("bob", 2000),
@@ -185,11 +154,11 @@ fn test_multi_user_privacy_mixing() {
     let (puzzle_program, puzzle_hash) = create_test_puzzle("1000");
 
     for (user, amount) in &users {
-        let spend_secret = string_to_spend_secret(&format!("{}_mixing_coin", user));
-        let coin = PrivateCoin::new(spend_secret, puzzle_hash, *amount);
+        let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, *amount);
 
         sim.add_coin(
             coin.clone(),
+            &secrets,
             CoinMetadata {
                 owner: user.to_string(),
                 coin_type: CoinType::Regular,
@@ -197,62 +166,49 @@ fn test_multi_user_privacy_mixing() {
             },
         );
 
-        println!("{} coin nullifier: {}", user, hex::encode(coin.nullifier()));
-        coin_programs.push((coin, puzzle_program.clone()));
+        println!("{} coin nullifier: {}", user, hex::encode(secrets.nullifier()));
+        coin_programs.push((coin, puzzle_program.clone(), secrets));
     }
 
-    println!("Mixing {} coins...", coin_programs.len());
+    println!("mixing {} coins...", coin_programs.len());
     let mix_result = sim.spend_coins(coin_programs);
 
     match mix_result {
         Ok(tx) => {
-            println!("Privacy mixing succeeded");
-            println!("Transaction ID: {}", hex::encode(tx.id));
-            println!("Mixed {} nullifiers", tx.nullifiers.len());
+            println!("privacy mixing succeeded");
+            println!("transaction id: {}", hex::encode(tx.id));
+            println!("mixed {} nullifiers", tx.nullifiers.len());
             assert_eq!(tx.nullifiers.len(), users.len());
 
-            // All nullifiers should now be spent
             for nullifier in &tx.nullifiers {
                 assert!(sim.has_nullifier(nullifier));
             }
         }
         Err(e) => {
-            println!("Privacy mixing failed: {:?}", e);
-
-            // MISSING LOGIC: If this fails, we need to implement:
-            // 1. Proper puzzle code matching in spend_coins()
-            // 2. Batch proof generation for multiple coins
-            // 3. Transaction validation logic
-            println!("MISSING LOGIC NEEDED:");
-            println!("1. Puzzle code derivation from puzzle hash");
-            println!("2. Batch spending proof generation");
-            println!("3. Multi-coin transaction validation");
+            println!("privacy mixing failed: {:?}", e);
         }
     }
 }
 
 #[test]
 fn test_nullifier_uniqueness_across_amounts() {
-    // Test that different amounts don't affect nullifier (amount is not in nullifier calculation)
-    let spend_secret = string_to_spend_secret("amount_test");
     let puzzle_hash = string_to_puzzle_hash("amount_puzzle");
 
-    let coin_100 = PrivateCoin::new(spend_secret, puzzle_hash, 100);
-    let coin_1000 = PrivateCoin::new(spend_secret, puzzle_hash, 1000);
-    let coin_1000000 = PrivateCoin::new(spend_secret, puzzle_hash, 1000000);
+    let coin_100 = PrivateCoin::new(puzzle_hash, 100, test_serial_commitment());
+    let coin_1000 = PrivateCoin::new(puzzle_hash, 1000, test_serial_commitment());
+    let coin_1000000 = PrivateCoin::new(puzzle_hash, 1000000, test_serial_commitment());
 
-    // Same spend_secret and puzzle_hash should produce same nullifier regardless of amount
-    assert_eq!(coin_100.nullifier(), coin_1000.nullifier());
-    assert_eq!(coin_1000.nullifier(), coin_1000000.nullifier());
+    assert_eq!(coin_100.puzzle_hash, coin_1000.puzzle_hash);
+    assert_eq!(coin_100.serial_commitment, coin_1000.serial_commitment);
+    assert_eq!(coin_1000000.serial_commitment, test_serial_commitment());
 
-    println!("Nullifier is independent of coin amount");
+    println!("same serial_commitment used for different amounts (test determinism)");
 }
 
 #[test]
 fn test_simulator_state_tracking() {
     let mut sim = CLVMZkSimulator::new();
 
-    // Create several coins
     let coins = vec![
         ("user1", "coin1", 1000),
         ("user1", "coin2", 2000),
@@ -262,13 +218,14 @@ fn test_simulator_state_tracking() {
 
     let (puzzle_program, puzzle_hash) = create_test_puzzle("1000");
     let mut created_coins = Vec::new();
+    let mut created_secrets = Vec::new();
 
     for (user, coin_id, amount) in coins {
-        let spend_secret = string_to_spend_secret(&format!("{}_{}", user, coin_id));
-        let coin = PrivateCoin::new(spend_secret, puzzle_hash, amount);
+        let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, amount);
 
         sim.add_coin(
             coin.clone(),
+            &secrets,
             CoinMetadata {
                 owner: user.to_string(),
                 coin_type: CoinType::Regular,
@@ -277,206 +234,127 @@ fn test_simulator_state_tracking() {
         );
 
         created_coins.push(coin);
+        created_secrets.push(secrets);
     }
 
-    // Check initial state
     let stats = sim.stats();
-    println!("Initial stats: {}", stats);
+    println!("initial stats: {}", stats);
     assert_eq!(stats.current_utxo_count, 4);
-    assert_eq!(stats.total_nullifiers, 0); // No spends yet
+    assert_eq!(stats.total_nullifiers, 0);
     assert_eq!(stats.total_transactions, 0);
 
-    // Spend first two coins
     let spend_result = sim.spend_coins(vec![
-        (created_coins[0].clone(), puzzle_program.clone()),
-        (created_coins[1].clone(), puzzle_program.clone()),
+        (created_coins[0].clone(), puzzle_program.clone(), created_secrets[0].clone()),
+        (created_coins[1].clone(), puzzle_program.clone(), created_secrets[1].clone()),
     ]);
 
     match spend_result {
         Ok(_tx) => {
-            println!("Spent 2 coins successfully");
+            println!("spent 2 coins successfully");
 
-            // Check updated state
             let updated_stats = sim.stats();
-            println!("Updated stats: {}", updated_stats);
-            assert_eq!(updated_stats.current_utxo_count, 2); // 2 coins remaining
-            assert_eq!(updated_stats.total_nullifiers, 2); // 2 coins spent
+            println!("updated stats: {}", updated_stats);
+            assert_eq!(updated_stats.current_utxo_count, 2);
+            assert_eq!(updated_stats.total_nullifiers, 2);
             assert_eq!(updated_stats.total_transactions, 1);
 
-            // Check specific nullifiers
-            assert!(sim.has_nullifier(&created_coins[0].nullifier()));
-            assert!(sim.has_nullifier(&created_coins[1].nullifier()));
-            assert!(!sim.has_nullifier(&created_coins[2].nullifier()));
-            assert!(!sim.has_nullifier(&created_coins[3].nullifier()));
+            assert!(sim.has_nullifier(&created_secrets[0].nullifier()));
+            assert!(sim.has_nullifier(&created_secrets[1].nullifier()));
+            assert!(!sim.has_nullifier(&created_secrets[2].nullifier()));
+            assert!(!sim.has_nullifier(&created_secrets[3].nullifier()));
         }
         Err(e) => {
-            println!("Spend failed: {:?}", e);
-            println!("MISSING LOGIC NEEDED:");
-            println!("1. Proper puzzle code lookup/generation");
-            println!("2. Spend bundle creation for real coins");
-            println!("3. ZK proof generation");
+            println!("spend failed: {:?}", e);
         }
     }
 }
 
 #[test]
 fn test_nullifier_determinism() {
-    // Test that nullifiers are completely deterministic
     let test_cases = vec![
         ("alice", "p2pk", 1000),
         ("bob", "multisig", 2000),
         ("charlie", "timelock", 500),
     ];
 
+    let secrets = test_coin_secrets();
+
     for (user, puzzle_type, amount) in test_cases {
-        let spend_secret = string_to_spend_secret(user);
         let puzzle_hash = string_to_puzzle_hash(puzzle_type);
 
-        // Create same coin multiple times
-        let coin1 = PrivateCoin::new(spend_secret, puzzle_hash, amount);
-        let coin2 = PrivateCoin::new(spend_secret, puzzle_hash, amount);
-        let coin3 = PrivateCoin::new(spend_secret, puzzle_hash, amount);
+        let coin1 = PrivateCoin::new(puzzle_hash, amount, test_serial_commitment());
+        let coin2 = PrivateCoin::new(puzzle_hash, amount, test_serial_commitment());
+        let coin3 = PrivateCoin::new(puzzle_hash, amount, test_serial_commitment());
 
-        // All should have identical nullifiers
-        assert_eq!(coin1.nullifier(), coin2.nullifier());
-        assert_eq!(coin2.nullifier(), coin3.nullifier());
+        assert_eq!(coin1.serial_commitment, coin2.serial_commitment);
+        assert_eq!(coin2.serial_commitment, coin3.serial_commitment);
 
         println!(
-            "{} nullifier is deterministic: {}",
+            "{} uses deterministic test secrets: {}",
             user,
-            hex::encode(coin1.nullifier())
+            hex::encode(secrets.nullifier())
         );
     }
 }
 
 #[test]
-fn test_puzzle_hash_binding_in_nullifier() {
-    // Verify that puzzle hash is actually included in nullifier calculation
-    let spend_secret = string_to_spend_secret("binding_test");
-    let puzzle1 = string_to_puzzle_hash("puzzle_type_1");
-    let puzzle2 = string_to_puzzle_hash("puzzle_type_2");
-
-    let coin1 = PrivateCoin::new(spend_secret, puzzle1, 1000);
-    let coin2 = PrivateCoin::new(spend_secret, puzzle2, 1000);
-
-    // Same secret, different puzzle = different nullifier
-    assert_ne!(coin1.nullifier(), coin2.nullifier());
-
-    // Manually verify nullifier construction matches expected algorithm
-    let expected_nullifier1 = clvm_zk::crypto_utils::generate_nullifier(&spend_secret, &puzzle1);
-
-    assert_eq!(coin1.nullifier(), expected_nullifier1);
-    println!("Nullifier construction algorithm verified");
-}
-
-#[test]
 fn test_large_scale_nullifier_uniqueness() {
-    // Stress test: generate many nullifiers and ensure they're all unique
     let mut nullifiers = std::collections::HashSet::new();
     let mut collision_count = 0;
 
+    let puzzle_hash = string_to_puzzle_hash("default");
+
     for user_id in 0..100 {
-        for coin_id in 0..10 {
-            for puzzle_variant in 0..5 {
-                let spend_secret =
-                    string_to_spend_secret(&format!("user{}coin{}", user_id, coin_id));
-                let puzzle_hash = string_to_puzzle_hash(&format!("puzzle{}", puzzle_variant));
+        for coin_id in 0..50 {
+            let (_, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
+            let nullifier = secrets.nullifier();
 
-                let coin = PrivateCoin::new(spend_secret, puzzle_hash, 1000);
-                let nullifier = coin.nullifier();
-
-                if !nullifiers.insert(nullifier) {
-                    collision_count += 1;
-                    println!(
-                        "Collision found for user={}, coin={}, puzzle={}",
-                        user_id, coin_id, puzzle_variant
-                    );
-                }
+            if !nullifiers.insert(nullifier) {
+                collision_count += 1;
+                println!("collision found for user={}, coin={}", user_id, coin_id);
             }
         }
     }
 
-    let total_generated = 100 * 10 * 5; // 5000 nullifiers
+    let total_generated = 100 * 50;
     println!(
-        "Generated {} nullifiers with {} collisions",
+        "generated {} nullifiers with {} collisions",
         total_generated, collision_count
     );
-    assert_eq!(collision_count, 0, "No nullifier collisions should occur");
+    assert_eq!(collision_count, 0);
     assert_eq!(nullifiers.len(), total_generated);
 
-    println!("Large-scale nullifier uniqueness verified");
+    println!("large-scale nullifier uniqueness verified");
 }
 
 #[test]
 fn test_simulator_reset() {
     let mut sim = CLVMZkSimulator::new();
 
-    // Add some coins and spend them
     let (puzzle_program, puzzle_hash) = create_test_puzzle("1000");
-    let coin = PrivateCoin::new(string_to_spend_secret("reset_test"), puzzle_hash, 1000);
+    let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
 
     sim.add_coin(
         coin.clone(),
+        &secrets,
         CoinMetadata {
             owner: "test".to_string(),
             coin_type: CoinType::Regular,
-            notes: "Reset test".to_string(),
+            notes: "reset test".to_string(),
         },
     );
 
-    // Attempt spend (may fail due to missing logic)
-    let _ = sim.spend_coins(vec![(coin.clone(), puzzle_program)]);
+    let _ = sim.spend_coins(vec![(coin.clone(), puzzle_program, secrets.clone())]);
 
-    // Reset simulator
     sim.reset();
 
-    // Should be back to initial state
     let stats = sim.stats();
     assert_eq!(stats.current_utxo_count, 0);
     assert_eq!(stats.total_nullifiers, 0);
     assert_eq!(stats.total_transactions, 0);
     assert_eq!(stats.current_block_height, 0);
 
-    // Should not have any nullifiers
-    assert!(!sim.has_nullifier(&coin.nullifier()));
+    assert!(!sim.has_nullifier(&secrets.nullifier()));
 
-    println!("Simulator reset functionality verified");
+    println!("simulator reset functionality verified");
 }
-
-// ============================================================================
-// Missing Logic Analysis
-// ============================================================================
-
-/*
-MISSING LOGIC ANALYSIS - UPDATED:
-
-MAJOR PROGRESS: 9/10 tests now pass! The core simulator functionality is working.
-
-REMAINING ISSUE:
-
-1. **Nullifier Calculation Inconsistency** (test_double_spend_prevention fails):
-   - The test creates coins with nullifiers calculated one way
-   - The spending system calculates nullifiers differently during proof generation
-   - Error: "Nullifier mismatch: expected 954be763..., got 6e1ffe091b88..."
-   - Root cause: Inconsistency between:
-     * Test's puzzle creation: `create_test_puzzle()` generates simple string-based puzzle
-     * Spender's nullifier calculation: Uses actual CLVM puzzle hash from proof system
-   - Need: Consistent nullifier calculation across test and production code
-
-WORKING COMPONENTS (Major progress since initial analysis):
-Basic nullifier creation and determinism
-Cross-puzzle nullifier separation
-Nullifier uniqueness and collision resistance
-Simulator state tracking and reset
-Multi-user privacy mixing (ZK proof generation works!)
-Transaction validation and double-spend detection logic
-Batch transaction handling
-
-RECOMMENDED FIX:
-- Align test puzzle creation with actual CLVM puzzle hash calculation
-- Ensure `create_test_puzzle()` generates puzzles that hash consistently with the spender system
-- Alternative: Make nullifier calculation method consistent between PrivateCoin and Spender
-
-ANALYSIS: The ZK proof infrastructure is now working correctly! The only remaining issue
-is a nullifier calculation mismatch between the test harness and production code.
-*/


### PR DESCRIPTION
commitment scheme:
  serial_commitment = hash("clvm_zk_serial_v1.0" || serial_number || serial_randomness)
  coin_commitment = hash("clvm_zk_coin_v1.0" || amount || puzzle_hash || serial_commitment)

  each coin gets a random 32-byte serial_number and serial_randomness at creation. the serial is committed via serial_commitment, which gets embedded in coin_commitment alongside amount and puzzle_hash.
  coin_commitment goes into the merkle tree.

  nullifier scheme:
  nullifier = hash(serial_number || program_hash)

  when spending, the guest:
  1. verifies program_hash == puzzle_hash (proves running the coin's puzzle)
  2. reconstructs serial_commitment from private inputs
  3. reconstructs coin_commitment and verifies merkle membership
  4. computes nullifier = hash(serial_number || program_hash) and reveals it

  key properties:
  - each coin has exactly ONE valid nullifier for its (serial_number, program_hash) pair
  - serial_randomness excluded from nullifier → prevents linking nullifier to coin_commitment
  - merkle proof shows coin exists without revealing which specific coin
  - nullifier set tracks spent coins → double-spend impossible

  critical: losing serial_number or serial_randomness = permanent coin loss. see encrypted payment notes for backup/recovery.