### PR TITLE
fix opcodes, fix proof output

### DIFF
--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -143,12 +143,10 @@ impl MockBackend {
                         condition.args = vec![coin_commitment.to_vec()];
                         has_transformations = true;
                     }
-                    n => {
-                        return Err(ClvmZkError::ProofGenerationFailed(format!(
-                            "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
-                            n
-                        )))
-                    }
+                    n => return Err(ClvmZkError::ProofGenerationFailed(format!(
+                        "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
+                        n
+                    ))),
                 }
             }
         }
@@ -284,12 +282,10 @@ impl MockBackend {
                         condition.args = vec![coin_commitment.to_vec()];
                         has_transformations = true;
                     }
-                    n => {
-                        return Err(ClvmZkError::ProofGenerationFailed(format!(
-                            "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
-                            n
-                        )))
-                    }
+                    n => return Err(ClvmZkError::ProofGenerationFailed(format!(
+                        "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
+                        n
+                    ))),
                 }
             }
         }

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -75,7 +75,7 @@ impl MockBackend {
 
         // Parse conditions from output (list-based programs return condition structures)
         let mut conditions = clvm_zk_core::deserialize_clvm_output_to_conditions(&output_bytes)
-            .unwrap_or_else(|_| _runtime_conditions); // fallback to runtime conditions if parsing fails
+            .unwrap_or(_runtime_conditions); // fallback to runtime conditions if parsing fails
 
         // Transform CREATE_COIN conditions for output privacy
         let mut has_transformations = false;
@@ -216,7 +216,7 @@ impl MockBackend {
 
         // Parse conditions from output (list-based programs return condition structures)
         let mut conditions = clvm_zk_core::deserialize_clvm_output_to_conditions(&output_bytes)
-            .unwrap_or_else(|_| _runtime_conditions); // fallback to runtime conditions if parsing fails
+            .unwrap_or(_runtime_conditions); // fallback to runtime conditions if parsing fails
 
         // Transform CREATE_COIN conditions for output privacy
         let mut has_transformations = false;

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -143,10 +143,12 @@ impl MockBackend {
                         condition.args = vec![coin_commitment.to_vec()];
                         has_transformations = true;
                     }
-                    n => return Err(ClvmZkError::ProofGenerationFailed(format!(
+                    n => {
+                        return Err(ClvmZkError::ProofGenerationFailed(format!(
                         "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
                         n
-                    ))),
+                    )))
+                    }
                 }
             }
         }
@@ -282,10 +284,12 @@ impl MockBackend {
                         condition.args = vec![coin_commitment.to_vec()];
                         has_transformations = true;
                     }
-                    n => return Err(ClvmZkError::ProofGenerationFailed(format!(
+                    n => {
+                        return Err(ClvmZkError::ProofGenerationFailed(format!(
                         "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
                         n
-                    ))),
+                    )))
+                    }
                 }
             }
         }

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -91,9 +91,75 @@ fn main() {
 
     let mut evaluator = ClvmEvaluator::new(sp1_hasher, sp1_verify_bls, sp1_verify_ecdsa);
     evaluator.function_table = function_table;
-    let (output_bytes, _conditions) = evaluator
+    let (output_bytes, mut conditions) = evaluator
         .evaluate_clvm_program(&instance_bytecode)
         .expect("CLVM execution failed");
+
+    // Transform CREATE_COIN conditions for output privacy
+    let mut has_transformations = false;
+    for condition in conditions.iter_mut() {
+        if condition.opcode == 51 {
+            // CREATE_COIN opcode
+            match condition.args.len() {
+                2 => {
+                    // Transparent mode: CREATE_COIN(puzzle_hash, amount)
+                    // Leave as-is for testing/debugging
+                }
+                4 => {
+                    // Private mode: CREATE_COIN(puzzle_hash, amount, serial_num, serial_rand)
+                    let puzzle_hash = &condition.args[0];
+                    let amount_bytes = &condition.args[1];
+                    let serial_number = &condition.args[2];
+                    let serial_randomness = &condition.args[3];
+
+                    // Validate sizes
+                    assert_eq!(puzzle_hash.len(), 32, "puzzle_hash must be 32 bytes");
+                    assert_eq!(amount_bytes.len(), 8, "amount must be 8 bytes");
+                    assert_eq!(serial_number.len(), 32, "serial_number must be 32 bytes");
+                    assert_eq!(
+                        serial_randomness.len(),
+                        32,
+                        "serial_randomness must be 32 bytes"
+                    );
+
+                    // Parse amount
+                    let amount = u64::from_be_bytes(amount_bytes.as_slice().try_into().unwrap());
+
+                    // Compute serial_commitment
+                    let serial_domain = b"clvm_zk_serial_v1.0";
+                    let mut serial_data = [0u8; 83];
+                    serial_data[..19].copy_from_slice(serial_domain);
+                    serial_data[19..51].copy_from_slice(serial_number);
+                    serial_data[51..83].copy_from_slice(serial_randomness);
+                    let serial_commitment = sp1_hasher(&serial_data);
+
+                    // Compute coin_commitment
+                    let coin_domain = b"clvm_zk_coin_v1.0";
+                    let mut coin_data = [0u8; 89];
+                    coin_data[..17].copy_from_slice(coin_domain);
+                    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+                    coin_data[25..57].copy_from_slice(puzzle_hash);
+                    coin_data[57..89].copy_from_slice(&serial_commitment);
+                    let coin_commitment = sp1_hasher(&coin_data);
+
+                    // Replace args: [puzzle, amount, serial, rand] → [commitment]
+                    condition.args = vec![coin_commitment.to_vec()];
+                    has_transformations = true;
+                }
+                n => panic!(
+                    "CREATE_COIN must have 2 args (transparent) or 4 args (private), got {}",
+                    n
+                ),
+            }
+        }
+    }
+
+    // Only re-serialize if we actually transformed something
+    let final_output = if has_transformations {
+        clvm_zk_core::serialize_conditions_to_bytes(&conditions)
+    } else {
+        output_bytes
+    };
 
     let nullifier = match private_inputs.serial_commitment_data {
         Some(commitment_data) => {
@@ -158,16 +224,17 @@ fn main() {
                 "merkle root mismatch: coin not in current tree state"
             );
 
-            let mut nullifier_data = Vec::with_capacity(64);
+            let mut nullifier_data = Vec::with_capacity(72);
             nullifier_data.extend_from_slice(&serial_number);
             nullifier_data.extend_from_slice(&program_hash);
+            nullifier_data.extend_from_slice(&amount.to_be_bytes());
             Some(sp1_hasher(&nullifier_data))
         }
         None => None,
     };
 
     let clvm_output = ClvmResult {
-        output: output_bytes,
+        output: final_output,
         cost: 0,
     };
 

--- a/clvm_zk_core/src/chialisp/frontend.rs
+++ b/clvm_zk_core/src/chialisp/frontend.rs
@@ -271,16 +271,24 @@ fn parse_atom_expression(atom: String) -> Result<Expression, CompileError> {
         "AGG_SIG_ME" => Ok(Expression::number(50)),
         "CREATE_COIN" => Ok(Expression::number(51)),
         "RESERVE_FEE" => Ok(Expression::number(52)),
+        // Output/Messaging
+        "REMARK" => Ok(Expression::number(1)),
+        // Announcements
+        "CREATE_COIN_ANNOUNCEMENT" => Ok(Expression::number(60)),
+        "ASSERT_COIN_ANNOUNCEMENT" => Ok(Expression::number(61)),
+        "CREATE_PUZZLE_ANNOUNCEMENT" => Ok(Expression::number(62)),
+        "ASSERT_PUZZLE_ANNOUNCEMENT" => Ok(Expression::number(63)),
+        // Concurrency
         "ASSERT_CONCURRENT_SPEND" => Ok(Expression::number(64)),
         "ASSERT_CONCURRENT_PUZZLE" => Ok(Expression::number(65)),
+        // Messaging
+        "SEND_MESSAGE" => Ok(Expression::number(66)),
+        "RECEIVE_MESSAGE" => Ok(Expression::number(67)),
+        // Assertions
         "ASSERT_MY_COIN_ID" => Ok(Expression::number(70)),
         "ASSERT_MY_PARENT_ID" => Ok(Expression::number(71)),
         "ASSERT_MY_PUZZLEHASH" => Ok(Expression::number(72)),
         "ASSERT_MY_AMOUNT" => Ok(Expression::number(73)),
-        "CREATE_COIN_ANNOUNCEMENT" => Ok(Expression::number(74)),
-        "ASSERT_COIN_ANNOUNCEMENT" => Ok(Expression::number(75)),
-        "CREATE_PUZZLE_ANNOUNCEMENT" => Ok(Expression::number(76)),
-        "ASSERT_PUZZLE_ANNOUNCEMENT" => Ok(Expression::number(77)),
         _ => Ok(Expression::variable(atom)),
     }
 }

--- a/clvm_zk_core/src/lib.rs
+++ b/clvm_zk_core/src/lib.rs
@@ -1485,7 +1485,9 @@ pub fn extract_coin_commitments(proof_output: &ProofOutput) -> Result<Vec<[u8; 3
 }
 
 /// Deserialize CLVM output bytes to Vec<Condition>
-pub fn deserialize_clvm_output_to_conditions(output: &[u8]) -> Result<Vec<Condition>, &'static str> {
+pub fn deserialize_clvm_output_to_conditions(
+    output: &[u8],
+) -> Result<Vec<Condition>, &'static str> {
     let mut parser = ClvmParser::new(output);
     let parsed = parser.parse()?;
 

--- a/clvm_zk_core/src/lib.rs
+++ b/clvm_zk_core/src/lib.rs
@@ -166,7 +166,6 @@ impl ClvmEvaluator {
                 ClvmOperator::Modulo => self.handle_op_modulo(args, conditions),
                 ClvmOperator::Equal => self.handle_op_equal(args, conditions),
                 ClvmOperator::GreaterThan => self.handle_op_greater(args, conditions),
-                ClvmOperator::LessThan => self.handle_op_less(args, conditions),
                 ClvmOperator::If => self.handle_op_if(args, None, conditions),
                 ClvmOperator::Cons => self.handle_op_cons(args, conditions),
                 ClvmOperator::First => self.handle_op_first(args, conditions),
@@ -191,6 +190,7 @@ impl ClvmEvaluator {
                 // Conditions
                 ClvmOperator::AggSigMe => self.handle_op_agg_sig_me(args, conditions),
                 ClvmOperator::AggSigUnsafe => self.handle_op_agg_sig_unsafe(args, conditions),
+                ClvmOperator::Remark => self.handle_op_remark(args, conditions),
                 ClvmOperator::CreateCoin => self.handle_op_create_coin(args, conditions),
                 ClvmOperator::ReserveFee => self.handle_op_reserve_fee(args, conditions),
                 ClvmOperator::CreateCoinAnnouncement => {
@@ -205,6 +205,14 @@ impl ClvmEvaluator {
                 ClvmOperator::AssertPuzzleAnnouncement => {
                     self.handle_op_assert_puzzle_announcement(args, conditions)
                 }
+                ClvmOperator::AssertConcurrentSpend => {
+                    self.handle_op_assert_concurrent_spend(args, conditions)
+                }
+                ClvmOperator::AssertConcurrentPuzzle => {
+                    self.handle_op_assert_concurrent_puzzle(args, conditions)
+                }
+                ClvmOperator::SendMessage => self.handle_op_send_message(args, conditions),
+                ClvmOperator::ReceiveMessage => self.handle_op_receive_message(args, conditions),
                 ClvmOperator::AssertMyCoinId => self.handle_op_assert_my_coin_id(args, conditions),
                 ClvmOperator::AssertMyParentId => {
                     self.handle_op_assert_my_parent_id(args, conditions)
@@ -213,12 +221,6 @@ impl ClvmEvaluator {
                     self.handle_op_assert_my_puzzle_hash(args, conditions)
                 }
                 ClvmOperator::AssertMyAmount => self.handle_op_assert_my_amount(args, conditions),
-                ClvmOperator::AssertConcurrentSpend => {
-                    self.handle_op_assert_concurrent_spend(args, conditions)
-                }
-                ClvmOperator::AssertConcurrentPuzzle => {
-                    self.handle_op_assert_concurrent_puzzle(args, conditions)
-                }
             },
             None => {
                 // Handle opcodes not in the enum (like SHA-256) using evaluator
@@ -546,21 +548,6 @@ impl ClvmEvaluator {
         ))
     }
 
-    pub fn handle_op_less(
-        &mut self,
-        args: &ClvmValue,
-        conditions: &mut Vec<Condition>,
-    ) -> Result<ClvmValue, &'static str> {
-        let (a, b) = self.extract_binary_clvm_args_with_params(args, conditions)?;
-        Ok(number_to_atom(
-            if atom_to_number(&a)? < atom_to_number(&b)? {
-                1
-            } else {
-                0
-            },
-        ))
-    }
-
     pub fn handle_op_equal(
         &mut self,
         args: &ClvmValue,
@@ -804,17 +791,6 @@ impl ClvmEvaluator {
                     let a = atom_to_number(&left)?;
                     let b = atom_to_number(&right)?;
                     Ok(if a > b {
-                        ClvmValue::Atom(vec![1])
-                    } else {
-                        ClvmValue::Atom(vec![])
-                    })
-                }
-                ClvmOperator::LessThan => {
-                    let (left, right) =
-                        self.extract_binary_clvm_args_evaled_with_env(args, env, conditions)?;
-                    let a = atom_to_number(&left)?;
-                    let b = atom_to_number(&right)?;
-                    Ok(if a < b {
                         ClvmValue::Atom(vec![1])
                     } else {
                         ClvmValue::Atom(vec![])
@@ -1132,7 +1108,7 @@ impl ClvmEvaluator {
         args: &ClvmValue,
         conditions: &mut Vec<Condition>,
     ) -> Result<ClvmValue, &'static str> {
-        self.handle_single_arg_condition(74, args, conditions)
+        self.handle_single_arg_condition(60, args, conditions)
     }
 
     fn handle_op_assert_coin_announcement(
@@ -1140,7 +1116,7 @@ impl ClvmEvaluator {
         args: &ClvmValue,
         conditions: &mut Vec<Condition>,
     ) -> Result<ClvmValue, &'static str> {
-        self.handle_single_arg_condition(75, args, conditions)
+        self.handle_single_arg_condition(61, args, conditions)
     }
 
     fn handle_op_create_puzzle_announcement(
@@ -1148,7 +1124,7 @@ impl ClvmEvaluator {
         args: &ClvmValue,
         conditions: &mut Vec<Condition>,
     ) -> Result<ClvmValue, &'static str> {
-        self.handle_single_arg_condition(76, args, conditions)
+        self.handle_single_arg_condition(62, args, conditions)
     }
 
     fn handle_op_assert_puzzle_announcement(
@@ -1156,7 +1132,31 @@ impl ClvmEvaluator {
         args: &ClvmValue,
         conditions: &mut Vec<Condition>,
     ) -> Result<ClvmValue, &'static str> {
-        self.handle_single_arg_condition(77, args, conditions)
+        self.handle_single_arg_condition(63, args, conditions)
+    }
+
+    fn handle_op_remark(
+        &mut self,
+        args: &ClvmValue,
+        conditions: &mut Vec<Condition>,
+    ) -> Result<ClvmValue, &'static str> {
+        self.handle_single_arg_condition(1, args, conditions)
+    }
+
+    fn handle_op_send_message(
+        &mut self,
+        args: &ClvmValue,
+        conditions: &mut Vec<Condition>,
+    ) -> Result<ClvmValue, &'static str> {
+        self.handle_single_arg_condition(66, args, conditions)
+    }
+
+    fn handle_op_receive_message(
+        &mut self,
+        args: &ClvmValue,
+        conditions: &mut Vec<Condition>,
+    ) -> Result<ClvmValue, &'static str> {
+        self.handle_single_arg_condition(67, args, conditions)
     }
 
     fn handle_op_call_function_context(
@@ -1447,6 +1447,147 @@ pub fn encode_clvm_value(value: ClvmValue) -> Vec<u8> {
             result
         }
     }
+}
+
+/// Convert conditions back to CLVM serialized format
+/// Takes a Vec<Condition> and returns serialized bytes representing a list of conditions
+pub fn serialize_conditions_to_bytes(conditions: &[Condition]) -> Vec<u8> {
+    // Convert conditions to CLVM list structure
+    let clvm_list = conditions_to_clvm_value(conditions);
+    encode_clvm_value(clvm_list)
+}
+
+/// Extract coin commitments from proof output
+/// Returns all CREATE_COIN commitments (opcode 51 with 1 arg)
+pub fn extract_coin_commitments(proof_output: &ProofOutput) -> Result<Vec<[u8; 32]>, &'static str> {
+    // Deserialize the clvm output to get conditions
+    let conditions = deserialize_clvm_output_to_conditions(&proof_output.clvm_res.output)?;
+
+    let mut commitments = Vec::new();
+    for condition in conditions {
+        if condition.opcode == 51 {
+            // CREATE_COIN
+            if condition.args.len() != 1 {
+                return Err("CREATE_COIN in proof output must have 1 arg (coin_commitment)");
+            }
+
+            if condition.args[0].len() != 32 {
+                return Err("coin_commitment must be 32 bytes");
+            }
+
+            let mut commitment = [0u8; 32];
+            commitment.copy_from_slice(&condition.args[0]);
+            commitments.push(commitment);
+        }
+    }
+
+    Ok(commitments)
+}
+
+/// Deserialize CLVM output bytes to Vec<Condition>
+pub fn deserialize_clvm_output_to_conditions(output: &[u8]) -> Result<Vec<Condition>, &'static str> {
+    let mut parser = ClvmParser::new(output);
+    let parsed = parser.parse()?;
+
+    // Parse list of conditions: ((opcode1 args...) (opcode2 args...) ...)
+    clvm_value_to_conditions(&parsed)
+}
+
+/// Convert ClvmValue to Vec<Condition>
+fn clvm_value_to_conditions(value: &ClvmValue) -> Result<Vec<Condition>, &'static str> {
+    let mut conditions = Vec::new();
+
+    // Traverse the list
+    let mut current = value;
+    loop {
+        match current {
+            ClvmValue::Atom(ref bytes) if bytes.is_empty() => {
+                // End of list (nil)
+                break;
+            }
+            ClvmValue::Cons(ref first, ref rest) => {
+                // Parse condition: (opcode arg1 arg2 ...)
+                let condition = parse_single_condition(first)?;
+                conditions.push(condition);
+                current = rest;
+            }
+            _ => return Err("invalid condition list structure"),
+        }
+    }
+
+    Ok(conditions)
+}
+
+/// Parse a single condition from ClvmValue
+fn parse_single_condition(value: &ClvmValue) -> Result<Condition, &'static str> {
+    match value {
+        ClvmValue::Cons(ref opcode_val, ref args_val) => {
+            // Extract opcode
+            let opcode = match opcode_val.as_ref() {
+                ClvmValue::Atom(ref bytes) if bytes.len() == 1 => bytes[0],
+                _ => return Err("condition opcode must be single byte"),
+            };
+
+            // Extract args
+            let args = extract_args_from_list(args_val)?;
+
+            Ok(Condition { opcode, args })
+        }
+        _ => Err("condition must be a cons pair"),
+    }
+}
+
+/// Extract arguments from CLVM list
+fn extract_args_from_list(value: &ClvmValue) -> Result<Vec<Vec<u8>>, &'static str> {
+    let mut args = Vec::new();
+    let mut current = value;
+
+    loop {
+        match current {
+            ClvmValue::Atom(ref bytes) if bytes.is_empty() => {
+                // End of list
+                break;
+            }
+            ClvmValue::Cons(ref first, ref rest) => {
+                match first.as_ref() {
+                    ClvmValue::Atom(ref bytes) => args.push(bytes.clone()),
+                    _ => return Err("argument must be an atom"),
+                }
+                current = rest;
+            }
+            _ => return Err("invalid argument list structure"),
+        }
+    }
+
+    Ok(args)
+}
+
+/// Convert Vec<Condition> to ClvmValue list representation
+/// Each condition becomes: (opcode arg1 arg2 ...)
+/// All conditions form a list: ((opcode1 args...) (opcode2 args...) ...)
+fn conditions_to_clvm_value(conditions: &[Condition]) -> ClvmValue {
+    // Build list from right to left (CLVM cons structure)
+    let mut result = ClvmValue::Atom(vec![]); // Start with nil (empty list)
+
+    for condition in conditions.iter().rev() {
+        // Build condition as (opcode arg1 arg2 ...)
+        let opcode = ClvmValue::Atom(vec![condition.opcode]);
+
+        // Build args list
+        let mut args_list = ClvmValue::Atom(vec![]); // nil
+        for arg in condition.args.iter().rev() {
+            let arg_value = ClvmValue::Atom(arg.clone());
+            args_list = ClvmValue::Cons(Box::new(arg_value), Box::new(args_list));
+        }
+
+        // Cons opcode with args: (opcode . args_list)
+        let condition_value = ClvmValue::Cons(Box::new(opcode), Box::new(args_list));
+
+        // Add to result list
+        result = ClvmValue::Cons(Box::new(condition_value), Box::new(result));
+    }
+
+    result
 }
 
 #[cfg(test)]

--- a/clvm_zk_core/src/operators.rs
+++ b/clvm_zk_core/src/operators.rs
@@ -18,7 +18,7 @@ pub enum ClvmOperator {
     // Comparison operators (ASCII codes)
     Equal,       // 61 (=)
     GreaterThan, // 62 (>)
-    LessThan,    // 60 (<)
+    // Note: LessThan removed - not in standard Chialisp, use (> b a) instead
 
     // CLVM primitives (ASCII codes)
     If,        // 105 (i)
@@ -39,23 +39,32 @@ pub enum ClvmOperator {
     EcdsaVerify,  // 200 (custom opcode for ECDSA verification)
     BlsVerify,    // 201 (custom opcode for BLS signature verification)
 
+    // Output/Messaging
+    Remark, // 1 (arbitrary output data)
+
     // Coin operations
     CreateCoin, // 51
     ReserveFee, // 52
+
+    // Announcements
+    CreateCoinAnnouncement,   // 60
+    AssertCoinAnnouncement,   // 61
+    CreatePuzzleAnnouncement, // 62
+    AssertPuzzleAnnouncement, // 63
+
+    // Concurrency
+    AssertConcurrentSpend,  // 64
+    AssertConcurrentPuzzle, // 65
+
+    // Messaging
+    SendMessage,    // 66
+    ReceiveMessage, // 67
 
     // Assertions
     AssertMyCoinId,         // 70
     AssertMyParentId,       // 71
     AssertMyPuzzleHash,     // 72
     AssertMyAmount,         // 73
-    AssertConcurrentSpend,  // 64
-    AssertConcurrentPuzzle, // 65
-
-    // Announcements
-    CreateCoinAnnouncement,   // 74
-    AssertCoinAnnouncement,   // 75
-    CreatePuzzleAnnouncement, // 76
-    AssertPuzzleAnnouncement, // 77
 
     // Runtime function calls
     CallFunction, // 250 (custom opcode for runtime function calls)
@@ -79,7 +88,6 @@ impl ClvmOperator {
             // Comparison (ASCII codes)
             ClvmOperator::Equal => 61,       // '='
             ClvmOperator::GreaterThan => 62, // '>'
-            ClvmOperator::LessThan => 60,    // '<'
 
             // CLVM primitives (ASCII codes)
             ClvmOperator::If => 105,        // 'i'
@@ -100,23 +108,32 @@ impl ClvmOperator {
             ClvmOperator::EcdsaVerify => 200,
             ClvmOperator::BlsVerify => 201,
 
+            // Output/Messaging
+            ClvmOperator::Remark => 1,
+
             // Coin operations
             ClvmOperator::CreateCoin => 51,
             ClvmOperator::ReserveFee => 52,
+
+            // Announcements
+            ClvmOperator::CreateCoinAnnouncement => 60,
+            ClvmOperator::AssertCoinAnnouncement => 61,
+            ClvmOperator::CreatePuzzleAnnouncement => 62,
+            ClvmOperator::AssertPuzzleAnnouncement => 63,
+
+            // Concurrency
+            ClvmOperator::AssertConcurrentSpend => 64,
+            ClvmOperator::AssertConcurrentPuzzle => 65,
+
+            // Messaging
+            ClvmOperator::SendMessage => 66,
+            ClvmOperator::ReceiveMessage => 67,
 
             // Assertions
             ClvmOperator::AssertMyCoinId => 70,
             ClvmOperator::AssertMyParentId => 71,
             ClvmOperator::AssertMyPuzzleHash => 72,
             ClvmOperator::AssertMyAmount => 73,
-            ClvmOperator::AssertConcurrentSpend => 64,
-            ClvmOperator::AssertConcurrentPuzzle => 65,
-
-            // Announcements
-            ClvmOperator::CreateCoinAnnouncement => 74,
-            ClvmOperator::AssertCoinAnnouncement => 75,
-            ClvmOperator::CreatePuzzleAnnouncement => 76,
-            ClvmOperator::AssertPuzzleAnnouncement => 77,
 
             // Runtime function calls
             ClvmOperator::CallFunction => 150,
@@ -139,7 +156,6 @@ impl ClvmOperator {
             // Comparison
             "=" => Some(ClvmOperator::Equal),
             ">" => Some(ClvmOperator::GreaterThan),
-            "<" => Some(ClvmOperator::LessThan),
 
             // CLVM primitives
             "i" => Some(ClvmOperator::If),
@@ -161,23 +177,32 @@ impl ClvmOperator {
             "ecdsa_verify" => Some(ClvmOperator::EcdsaVerify),
             "bls_verify" => Some(ClvmOperator::BlsVerify),
 
+            // Output/Messaging
+            "remark" => Some(ClvmOperator::Remark),
+
             // Coin operations
             "create_coin" => Some(ClvmOperator::CreateCoin),
             "reserve_fee" => Some(ClvmOperator::ReserveFee),
-
-            // Assertions
-            "assert_my_coin_id" => Some(ClvmOperator::AssertMyCoinId),
-            "assert_my_parent_id" => Some(ClvmOperator::AssertMyParentId),
-            "assert_my_puzzle_hash" => Some(ClvmOperator::AssertMyPuzzleHash),
-            "assert_my_amount" => Some(ClvmOperator::AssertMyAmount),
-            "assert_concurrent_spend" => Some(ClvmOperator::AssertConcurrentSpend),
-            "assert_concurrent_puzzle" => Some(ClvmOperator::AssertConcurrentPuzzle),
 
             // Announcements
             "create_coin_announcement" => Some(ClvmOperator::CreateCoinAnnouncement),
             "assert_coin_announcement" => Some(ClvmOperator::AssertCoinAnnouncement),
             "create_puzzle_announcement" => Some(ClvmOperator::CreatePuzzleAnnouncement),
             "assert_puzzle_announcement" => Some(ClvmOperator::AssertPuzzleAnnouncement),
+
+            // Concurrency
+            "assert_concurrent_spend" => Some(ClvmOperator::AssertConcurrentSpend),
+            "assert_concurrent_puzzle" => Some(ClvmOperator::AssertConcurrentPuzzle),
+
+            // Messaging
+            "send_message" => Some(ClvmOperator::SendMessage),
+            "receive_message" => Some(ClvmOperator::ReceiveMessage),
+
+            // Assertions
+            "assert_my_coin_id" => Some(ClvmOperator::AssertMyCoinId),
+            "assert_my_parent_id" => Some(ClvmOperator::AssertMyParentId),
+            "assert_my_puzzle_hash" => Some(ClvmOperator::AssertMyPuzzleHash),
+            "assert_my_amount" => Some(ClvmOperator::AssertMyAmount),
 
             // Host-only helpers
             "list" => Some(ClvmOperator::List),
@@ -199,7 +224,6 @@ impl ClvmOperator {
             // Comparison (ASCII codes)
             61 => Some(ClvmOperator::Equal),
             62 => Some(ClvmOperator::GreaterThan),
-            60 => Some(ClvmOperator::LessThan),
 
             // CLVM primitives (ASCII codes)
             105 => Some(ClvmOperator::If),
@@ -220,23 +244,28 @@ impl ClvmOperator {
             200 => Some(ClvmOperator::EcdsaVerify),
             201 => Some(ClvmOperator::BlsVerify),
 
+            // Output/Messaging
+            1 => Some(ClvmOperator::Remark),
+
             // Coin operations
             51 => Some(ClvmOperator::CreateCoin),
             52 => Some(ClvmOperator::ReserveFee),
+
+            // Note: Announcement conditions (60-63) are NOT in from_opcode() because they
+            // conflict with CLVM operators (60='<', 61='=', 62='>'). Their opcode() mappings
+            // are used by handlers to create condition structures.
+
+            // Concurrency
+            64 => Some(ClvmOperator::AssertConcurrentSpend),
+            65 => Some(ClvmOperator::AssertConcurrentPuzzle),
+
+            // Note: Messaging conditions (66-67) not in from_opcode() to avoid conflicts
 
             // Assertions
             70 => Some(ClvmOperator::AssertMyCoinId),
             71 => Some(ClvmOperator::AssertMyParentId),
             72 => Some(ClvmOperator::AssertMyPuzzleHash),
             73 => Some(ClvmOperator::AssertMyAmount),
-            64 => Some(ClvmOperator::AssertConcurrentSpend),
-            65 => Some(ClvmOperator::AssertConcurrentPuzzle),
-
-            // Announcements
-            74 => Some(ClvmOperator::CreateCoinAnnouncement),
-            75 => Some(ClvmOperator::AssertCoinAnnouncement),
-            76 => Some(ClvmOperator::CreatePuzzleAnnouncement),
-            77 => Some(ClvmOperator::AssertPuzzleAnnouncement),
 
             // Runtime function calls
             150 => Some(ClvmOperator::CallFunction),
@@ -256,7 +285,6 @@ impl ClvmOperator {
             | ClvmOperator::Modulo
             | ClvmOperator::Equal
             | ClvmOperator::GreaterThan
-            | ClvmOperator::LessThan
             | ClvmOperator::Cons
             | ClvmOperator::Apply
             | ClvmOperator::DivMod
@@ -267,6 +295,7 @@ impl ClvmOperator {
             | ClvmOperator::Rest
             | ClvmOperator::ListCheck
             | ClvmOperator::Quote
+            | ClvmOperator::Remark
             | ClvmOperator::AssertMyCoinId
             | ClvmOperator::AssertMyParentId
             | ClvmOperator::AssertMyPuzzleHash
@@ -277,7 +306,9 @@ impl ClvmOperator {
             | ClvmOperator::CreatePuzzleAnnouncement
             | ClvmOperator::AssertPuzzleAnnouncement
             | ClvmOperator::AssertConcurrentSpend
-            | ClvmOperator::AssertConcurrentPuzzle => Some(1),
+            | ClvmOperator::AssertConcurrentPuzzle
+            | ClvmOperator::SendMessage
+            | ClvmOperator::ReceiveMessage => Some(1),
 
             // Ternary operators (3 arguments)
             ClvmOperator::If
@@ -303,7 +334,6 @@ impl ClvmOperator {
             ClvmOperator::Modulo => "%",
             ClvmOperator::Equal => "=",
             ClvmOperator::GreaterThan => ">",
-            ClvmOperator::LessThan => "<",
             ClvmOperator::If => "i",
             ClvmOperator::First => "f",
             ClvmOperator::Rest => "r",
@@ -317,18 +347,21 @@ impl ClvmOperator {
             ClvmOperator::AggSigMe => "agg_sig_me",
             ClvmOperator::EcdsaVerify => "ecdsa_verify",
             ClvmOperator::BlsVerify => "bls_verify",
+            ClvmOperator::Remark => "remark",
             ClvmOperator::CreateCoin => "create_coin",
             ClvmOperator::ReserveFee => "reserve_fee",
-            ClvmOperator::AssertMyCoinId => "assert_my_coin_id",
-            ClvmOperator::AssertMyParentId => "assert_my_parent_id",
-            ClvmOperator::AssertMyPuzzleHash => "assert_my_puzzle_hash",
-            ClvmOperator::AssertMyAmount => "assert_my_amount",
-            ClvmOperator::AssertConcurrentSpend => "assert_concurrent_spend",
-            ClvmOperator::AssertConcurrentPuzzle => "assert_concurrent_puzzle",
             ClvmOperator::CreateCoinAnnouncement => "create_coin_announcement",
             ClvmOperator::AssertCoinAnnouncement => "assert_coin_announcement",
             ClvmOperator::CreatePuzzleAnnouncement => "create_puzzle_announcement",
             ClvmOperator::AssertPuzzleAnnouncement => "assert_puzzle_announcement",
+            ClvmOperator::AssertConcurrentSpend => "assert_concurrent_spend",
+            ClvmOperator::AssertConcurrentPuzzle => "assert_concurrent_puzzle",
+            ClvmOperator::SendMessage => "send_message",
+            ClvmOperator::ReceiveMessage => "receive_message",
+            ClvmOperator::AssertMyCoinId => "assert_my_coin_id",
+            ClvmOperator::AssertMyParentId => "assert_my_parent_id",
+            ClvmOperator::AssertMyPuzzleHash => "assert_my_puzzle_hash",
+            ClvmOperator::AssertMyAmount => "assert_my_amount",
             ClvmOperator::CallFunction => "call_function",
             ClvmOperator::List => "list",
         }

--- a/clvm_zk_core/src/operators.rs
+++ b/clvm_zk_core/src/operators.rs
@@ -61,10 +61,10 @@ pub enum ClvmOperator {
     ReceiveMessage, // 67
 
     // Assertions
-    AssertMyCoinId,         // 70
-    AssertMyParentId,       // 71
-    AssertMyPuzzleHash,     // 72
-    AssertMyAmount,         // 73
+    AssertMyCoinId,     // 70
+    AssertMyParentId,   // 71
+    AssertMyPuzzleHash, // 72
+    AssertMyAmount,     // 73
 
     // Runtime function calls
     CallFunction, // 250 (custom opcode for runtime function calls)

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -185,7 +185,11 @@ impl CLVMZkSimulator {
             Vec<crate::ProgramParameter>,
             clvm_zk_core::coin_commitment::CoinSecrets,
         )>,
-        output_coins: Vec<(PrivateCoin, clvm_zk_core::coin_commitment::CoinSecrets, CoinMetadata)>,
+        output_coins: Vec<(
+            PrivateCoin,
+            clvm_zk_core::coin_commitment::CoinSecrets,
+            CoinMetadata,
+        )>,
     ) -> Result<SimulatedTransaction, SimulatorError> {
         let merkle_root = self
             .coin_tree
@@ -233,18 +237,20 @@ impl CLVMZkSimulator {
         for bundle in &spend_bundles {
             // Try to parse CLVM output as conditions
             // If it fails (e.g., simple return value), skip extraction
-            if let Ok(conditions) = clvm_zk_core::deserialize_clvm_output_to_conditions(&bundle.public_conditions) {
+            if let Ok(conditions) =
+                clvm_zk_core::deserialize_clvm_output_to_conditions(&bundle.public_conditions)
+            {
                 // Extract CREATE_COIN commitments (opcode 51)
                 for condition in conditions {
                     if condition.opcode == 51 {
                         if condition.args.len() != 1 {
                             return Err(SimulatorError::TestFailed(
-                                "CREATE_COIN must have 1 arg (coin_commitment)".to_string()
+                                "CREATE_COIN must have 1 arg (coin_commitment)".to_string(),
                             ));
                         }
                         if condition.args[0].len() != 32 {
                             return Err(SimulatorError::TestFailed(
-                                "coin_commitment must be 32 bytes".to_string()
+                                "coin_commitment must be 32 bytes".to_string(),
                             ));
                         }
                         let mut commitment = [0u8; 32];

--- a/tests/bls_signature_tests.rs
+++ b/tests/bls_signature_tests.rs
@@ -116,8 +116,11 @@ fn test_bls_verify_compilation() {
 
             // BLS verify returns true (empty atom) on success
             let result_bytes = &conditions[0].args[0];
-            assert!(result_bytes.is_empty() || result_bytes == &vec![1],
-                    "BLS verify should return true, got: {:?}", result_bytes);
+            assert!(
+                result_bytes.is_empty() || result_bytes == &vec![1],
+                "BLS verify should return true, got: {:?}",
+                result_bytes
+            );
 
             println!("Valid BLS signature correctly verified ✓");
         }
@@ -200,8 +203,11 @@ fn test_bls_program_with_backend() {
 
             // Result should be 1 for success
             let result_bytes = &conditions[0].args[0];
-            assert!(result_bytes.is_empty() || result_bytes == &vec![1],
-                    "BLS verify should return 1 for success, got: {:?}", result_bytes);
+            assert!(
+                result_bytes.is_empty() || result_bytes == &vec![1],
+                "BLS verify should return 1 for success, got: {:?}",
+                result_bytes
+            );
 
             println!("BLS signature verified successfully ✓");
         }

--- a/tests/fuzz_tests.rs
+++ b/tests/fuzz_tests.rs
@@ -50,12 +50,18 @@ async fn fuzz_arithmetic_operations() -> Result<(), String> {
                 let a = *a;
                 let b = *b;
                 task::spawn_blocking(move || {
-                    let expr = format!("(mod (a b) ({op} a b))");
+                    let expr = format!("(mod (a b) (list (list REMARK ({op} a b))))");
                     let result = test_expression(&expr, &[a as i64, b as i64]);
 
                     match result {
                         TestResult::Success(output) => {
-                            test_info!("[PASS] {expr} = {}", output[0]);
+                            // Parse announcement condition to get result
+                            let conditions = clvm_zk_core::deserialize_clvm_output_to_conditions(&output)
+                                .expect("failed to parse conditions");
+                            assert_eq!(conditions.len(), 1, "expected 1 announcement");
+                            assert_eq!(conditions[0].opcode, 1, "expected REMARK");
+                            let result_bytes = &conditions[0].args[0];
+                            test_info!("[PASS] {expr} = {:?}", result_bytes);
                             Ok((op, a, b))
                         }
                         // Any other result for a known-good input is a test failure.
@@ -140,54 +146,41 @@ async fn fuzz_comparison_operations() -> Result<(), String> {
                 let a = *a;
                 let b = *b;
                 task::spawn_blocking(move || {
-                    // BEGIN inlined test_comparison logic
-
-                    let expr = format!("(mod (a b) ({op} a b))");
-
-                    // assuming test_expression returns TestResult and works same way as before
+                    let expr = format!("(mod (a b) (list (list REMARK ({op} a b))))");
                     let result = test_expression(&expr, &[a, b]);
 
                     if let TestResult::Success(output) = &result {
-                        // CLVM encoding: true=1 (encoded as [1]), false=0 (empty atom, encoded as [0x80])
-                        if output.len() == 1 && (output[0] == 1 || output[0] == 0x80) {
-                            let expected = match op.as_str() {
-                                "=" => {
-                                    if a == b {
-                                        1
-                                    } else {
-                                        0x80 // false is encoded as 0x80 (empty atom)
-                                    }
-                                }
-                                ">" => {
-                                    if a > b {
-                                        1
-                                    } else {
-                                        0x80 // false is encoded as 0x80 (empty atom)
-                                    }
-                                }
-                                _ => {
-                                    return TestResult::VerifyFailed(format!(
-                                        "Unknown operator: {op}"
-                                    ))
-                                }
-                            };
-                            if output[0] == expected {
-                                let result_str = if output[0] == 1 { "true" } else { "false" };
-                                test_info!("{expr} = {} (correct)", result_str);
-                            } else {
-                                return TestResult::VerifyFailed(format!(
-                                    "Logic error: expected {expected}, got {}",
-                                    output[0]
-                                ));
-                            }
+                        // Parse announcement condition
+                        let conditions = match clvm_zk_core::deserialize_clvm_output_to_conditions(output) {
+                            Ok(c) => c,
+                            Err(e) => return TestResult::VerifyFailed(format!("failed to parse conditions: {}", e)),
+                        };
+
+                        if conditions.len() != 1 || conditions[0].opcode != 1 {
+                            return TestResult::VerifyFailed("expected 1 REMARK".to_string());
+                        }
+
+                        let result_bytes = &conditions[0].args[0];
+
+                        // Check if result matches expected
+                        // In CLVM: true = non-empty (like [1]), false = empty []
+                        let expected = match op.as_str() {
+                            "=" => a == b,
+                            ">" => a > b,
+                            _ => return TestResult::VerifyFailed(format!("Unknown operator: {op}")),
+                        };
+
+                        let is_true = !result_bytes.is_empty();
+                        if is_true == expected {
+                            let result_str = if is_true { "true" } else { "false" };
+                            test_info!("{expr} = {} (correct)", result_str);
                         } else {
                             return TestResult::VerifyFailed(format!(
-                                "Invalid output format: expected single byte 1 or 0x80, got {output:?}"
+                                "Logic error: expected {}, got {}",
+                                expected, is_true
                             ));
                         }
                     }
-
-                    // END inlined test_comparison logic
 
                     result
                 })
@@ -617,7 +610,7 @@ fn comprehensive_fuzz_conditions_security() -> Result<(), String> {
             vec![ProgramParameter::int(100)],
         ),
         (
-            "CREATE_COIN_ANNOUNCEMENT",
+            "REMARK",
             "(mod (a) (create_coin_announcement a))",
             vec![ProgramParameter::int(777)],
         ),

--- a/tests/fuzz_tests.rs
+++ b/tests/fuzz_tests.rs
@@ -56,8 +56,9 @@ async fn fuzz_arithmetic_operations() -> Result<(), String> {
                     match result {
                         TestResult::Success(output) => {
                             // Parse announcement condition to get result
-                            let conditions = clvm_zk_core::deserialize_clvm_output_to_conditions(&output)
-                                .expect("failed to parse conditions");
+                            let conditions =
+                                clvm_zk_core::deserialize_clvm_output_to_conditions(&output)
+                                    .expect("failed to parse conditions");
                             assert_eq!(conditions.len(), 1, "expected 1 announcement");
                             assert_eq!(conditions[0].opcode, 1, "expected REMARK");
                             let result_bytes = &conditions[0].args[0];
@@ -151,10 +152,16 @@ async fn fuzz_comparison_operations() -> Result<(), String> {
 
                     if let TestResult::Success(output) = &result {
                         // Parse announcement condition
-                        let conditions = match clvm_zk_core::deserialize_clvm_output_to_conditions(output) {
-                            Ok(c) => c,
-                            Err(e) => return TestResult::VerifyFailed(format!("failed to parse conditions: {}", e)),
-                        };
+                        let conditions =
+                            match clvm_zk_core::deserialize_clvm_output_to_conditions(output) {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    return TestResult::VerifyFailed(format!(
+                                        "failed to parse conditions: {}",
+                                        e
+                                    ))
+                                }
+                            };
 
                         if conditions.len() != 1 || conditions[0].opcode != 1 {
                             return TestResult::VerifyFailed("expected 1 REMARK".to_string());
@@ -167,7 +174,9 @@ async fn fuzz_comparison_operations() -> Result<(), String> {
                         let expected = match op.as_str() {
                             "=" => a == b,
                             ">" => a > b,
-                            _ => return TestResult::VerifyFailed(format!("Unknown operator: {op}")),
+                            _ => {
+                                return TestResult::VerifyFailed(format!("Unknown operator: {op}"))
+                            }
                         };
 
                         let is_true = !result_bytes.is_empty();

--- a/tests/proof_validation_tests.rs
+++ b/tests/proof_validation_tests.rs
@@ -300,8 +300,8 @@ async fn test_arithmetic_operations() -> Result<(), String> {
         ("%", 15, 7, 1),
         ("/", 20, 4, 5),
         ("%", 10, 3, 1),
-        (">", 10, 5, 1),      // 10 > 5 = true
-        (">", 5, 10, 0x80),   // 5 > 10 = false (encoded as 0x80)
+        (">", 10, 5, 1),    // 10 > 5 = true
+        (">", 5, 10, 0x80), // 5 > 10 = false (encoded as 0x80)
     ];
 
     let total_cases = test_cases.len();

--- a/tests/proof_validation_tests.rs
+++ b/tests/proof_validation_tests.rs
@@ -290,17 +290,18 @@ async fn test_complex_nested_expressions() -> Result<(), String> {
     Ok(())
 }
 
-/// Test arithmetic operations not covered in fuzz tests (/, %, <)
+/// Test arithmetic operations not covered in fuzz tests (/, %, >)
 #[tokio::test]
 async fn test_arithmetic_operations() -> Result<(), String> {
     // Note: CLVM encoding - true (1) = [1], false (0) = [0x80]
+    // Note: < operator removed (not in standard Chialisp), use > with reversed args
     let test_cases = vec![
         ("/", 15, 3, 5),
         ("%", 15, 7, 1),
         ("/", 20, 4, 5),
         ("%", 10, 3, 1),
-        ("<", 5, 10, 1),
-        ("<", 10, 5, 0x80), // false encoded as 0x80
+        (">", 10, 5, 1),      // 10 > 5 = true
+        (">", 5, 10, 0x80),   // 5 > 10 = false (encoded as 0x80)
     ];
 
     let total_cases = test_cases.len();

--- a/tests/test_condition_transformation.rs
+++ b/tests/test_condition_transformation.rs
@@ -1,0 +1,146 @@
+/// Unit test for CREATE_COIN transformation logic
+use clvm_zk_core::{hash_data, serialize_conditions_to_bytes, Condition};
+
+#[test]
+fn test_condition_transformation_logic() {
+    // Create a 4-arg CREATE_COIN condition (private mode)
+    let puzzle_hash = [0x42u8; 32];
+    let amount: u64 = 1000;
+    let serial_number = [0x11u8; 32];
+    let serial_randomness = [0x22u8; 32];
+
+    let mut condition = Condition {
+        opcode: 51, // CREATE_COIN
+        args: vec![
+            puzzle_hash.to_vec(),
+            amount.to_be_bytes().to_vec(),
+            serial_number.to_vec(),
+            serial_randomness.to_vec(),
+        ],
+    };
+
+    // Verify initial state
+    assert_eq!(condition.args.len(), 4, "should start with 4 args");
+
+    // Manually apply transformation (same logic as in guests)
+    let puzzle_hash_ref = &condition.args[0];
+    let amount_bytes = &condition.args[1];
+    let serial_num = &condition.args[2];
+    let serial_rand = &condition.args[3];
+
+    // Compute serial_commitment
+    let serial_domain = b"clvm_zk_serial_v1.0";
+    let mut serial_data = [0u8; 83];
+    serial_data[..19].copy_from_slice(serial_domain);
+    serial_data[19..51].copy_from_slice(serial_num);
+    serial_data[51..83].copy_from_slice(serial_rand);
+    let serial_commitment = hash_data(&serial_data);
+
+    // Compute coin_commitment
+    let coin_domain = b"clvm_zk_coin_v1.0";
+    let mut coin_data = [0u8; 89];
+    coin_data[..17].copy_from_slice(coin_domain);
+    coin_data[17..25].copy_from_slice(amount_bytes);
+    coin_data[25..57].copy_from_slice(puzzle_hash_ref);
+    coin_data[57..89].copy_from_slice(&serial_commitment);
+    let coin_commitment = hash_data(&coin_data);
+
+    // Transform: replace 4 args with 1 arg (commitment)
+    condition.args = vec![coin_commitment.to_vec()];
+
+    // Verify transformation
+    assert_eq!(condition.args.len(), 1, "should have 1 arg after transformation");
+    assert_eq!(condition.args[0].len(), 32, "commitment should be 32 bytes");
+
+    println!("✓ condition transformation logic works");
+    println!("  original: CREATE_COIN(puzzle[32], amount[8], serial[32], rand[32])");
+    println!("  transformed: CREATE_COIN(commitment[32])");
+    println!("  commitment: {}", hex::encode(&condition.args[0]));
+}
+
+#[test]
+fn test_condition_serialization() {
+    // Create simple conditions
+    let conditions = vec![
+        Condition {
+            opcode: 51,
+            args: vec![vec![0x01; 32]], // CREATE_COIN with 1 arg
+        },
+        Condition {
+            opcode: 52,
+            args: vec![vec![0x02; 8]], // RESERVE_FEE with 1 arg
+        },
+    ];
+
+    // Serialize
+    let serialized = serialize_conditions_to_bytes(&conditions);
+
+    // Verify we got bytes
+    assert!(!serialized.is_empty(), "serialization should produce bytes");
+
+    println!("✓ condition serialization works");
+    println!("  {} conditions → {} bytes", conditions.len(), serialized.len());
+}
+
+#[test]
+fn test_transparent_mode_preserved() {
+    // 2-arg CREATE_COIN should not be transformed
+    let condition = Condition {
+        opcode: 51,
+        args: vec![
+            vec![0x42; 32], // puzzle_hash
+            vec![0, 0, 0, 0, 0, 0, 3, 232], // amount = 1000 in big-endian
+        ],
+    };
+
+    // In transparent mode, we leave it as-is
+    assert_eq!(condition.args.len(), 2, "transparent mode has 2 args");
+
+    println!("✓ transparent mode (2-arg) preserved");
+}
+
+#[test]
+fn test_commitment_determinism() {
+    // Same inputs should produce same commitment
+    let puzzle = [0x42u8; 32];
+    let amount: u64 = 1000;
+    let serial = [0x11u8; 32];
+    let rand = [0x22u8; 32];
+
+    // Compute commitment twice
+    let commitment1 = compute_coin_commitment(&puzzle, amount, &serial, &rand);
+    let commitment2 = compute_coin_commitment(&puzzle, amount, &serial, &rand);
+
+    assert_eq!(commitment1, commitment2, "commitment should be deterministic");
+
+    // Different inputs should produce different commitment
+    let commitment3 = compute_coin_commitment(&puzzle, 2000, &serial, &rand);
+    assert_ne!(commitment1, commitment3, "different amount should change commitment");
+
+    println!("✓ commitment computation is deterministic");
+}
+
+// Helper function
+fn compute_coin_commitment(
+    puzzle_hash: &[u8; 32],
+    amount: u64,
+    serial_number: &[u8; 32],
+    serial_randomness: &[u8; 32],
+) -> [u8; 32] {
+    // Compute serial_commitment
+    let serial_domain = b"clvm_zk_serial_v1.0";
+    let mut serial_data = [0u8; 83];
+    serial_data[..19].copy_from_slice(serial_domain);
+    serial_data[19..51].copy_from_slice(serial_number);
+    serial_data[51..83].copy_from_slice(serial_randomness);
+    let serial_commitment = hash_data(&serial_data);
+
+    // Compute coin_commitment
+    let coin_domain = b"clvm_zk_coin_v1.0";
+    let mut coin_data = [0u8; 89];
+    coin_data[..17].copy_from_slice(coin_domain);
+    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+    coin_data[25..57].copy_from_slice(puzzle_hash);
+    coin_data[57..89].copy_from_slice(&serial_commitment);
+    hash_data(&coin_data)
+}

--- a/tests/test_condition_transformation.rs
+++ b/tests/test_condition_transformation.rs
@@ -49,7 +49,11 @@ fn test_condition_transformation_logic() {
     condition.args = vec![coin_commitment.to_vec()];
 
     // Verify transformation
-    assert_eq!(condition.args.len(), 1, "should have 1 arg after transformation");
+    assert_eq!(
+        condition.args.len(),
+        1,
+        "should have 1 arg after transformation"
+    );
     assert_eq!(condition.args[0].len(), 32, "commitment should be 32 bytes");
 
     println!("✓ condition transformation logic works");
@@ -79,7 +83,11 @@ fn test_condition_serialization() {
     assert!(!serialized.is_empty(), "serialization should produce bytes");
 
     println!("✓ condition serialization works");
-    println!("  {} conditions → {} bytes", conditions.len(), serialized.len());
+    println!(
+        "  {} conditions → {} bytes",
+        conditions.len(),
+        serialized.len()
+    );
 }
 
 #[test]
@@ -88,7 +96,7 @@ fn test_transparent_mode_preserved() {
     let condition = Condition {
         opcode: 51,
         args: vec![
-            vec![0x42; 32], // puzzle_hash
+            vec![0x42; 32],                 // puzzle_hash
             vec![0, 0, 0, 0, 0, 0, 3, 232], // amount = 1000 in big-endian
         ],
     };
@@ -111,11 +119,17 @@ fn test_commitment_determinism() {
     let commitment1 = compute_coin_commitment(&puzzle, amount, &serial, &rand);
     let commitment2 = compute_coin_commitment(&puzzle, amount, &serial, &rand);
 
-    assert_eq!(commitment1, commitment2, "commitment should be deterministic");
+    assert_eq!(
+        commitment1, commitment2,
+        "commitment should be deterministic"
+    );
 
     // Different inputs should produce different commitment
     let commitment3 = compute_coin_commitment(&puzzle, 2000, &serial, &rand);
-    assert_ne!(commitment1, commitment3, "different amount should change commitment");
+    assert_ne!(
+        commitment1, commitment3,
+        "different amount should change commitment"
+    );
 
     println!("✓ commitment computation is deterministic");
 }

--- a/tests/test_create_coin_privacy.rs
+++ b/tests/test_create_coin_privacy.rs
@@ -1,0 +1,226 @@
+/// Test CREATE_COIN transformation for output privacy
+use clvm_zk_core::{extract_coin_commitments, hash_data, ProgramParameter};
+
+#[cfg(feature = "mock")]
+use clvm_zk_mock::MockBackend;
+
+#[test]
+#[cfg(feature = "mock")]
+fn test_create_coin_private_mode() {
+    // Generate random serials for output coin
+    let serial_number: [u8; 32] = rand::random();
+    let serial_randomness: [u8; 32] = rand::random();
+
+    // Recipient and amount
+    let recipient_puzzle = [0x42u8; 32];
+    let amount: u64 = 1000;
+
+    // Chialisp program with 4-arg CREATE_COIN (private mode)
+    let program = r#"
+        (mod (recipient amount serial_num serial_rand)
+            (list (list CREATE_COIN recipient amount serial_num serial_rand)))
+    "#;
+
+    // Parameters: recipient, amount, serial_number, serial_randomness
+    let params = vec![
+        ProgramParameter::Bytes(recipient_puzzle.to_vec()),
+        ProgramParameter::Int(amount),
+        ProgramParameter::Bytes(serial_number.to_vec()),
+        ProgramParameter::Bytes(serial_randomness.to_vec()),
+    ];
+
+    // Generate proof
+    let backend = MockBackend::new().expect("failed to create backend");
+    let result = backend
+        .prove_chialisp_program(program, &params)
+        .expect("proof generation failed");
+
+    // Extract coin commitments from proof output
+    let commitments = extract_coin_commitments(&result.proof_output)
+        .expect("failed to extract commitments");
+
+    // Should have exactly 1 commitment
+    assert_eq!(commitments.len(), 1, "expected 1 coin commitment");
+
+    // Verify commitment was computed correctly
+    let expected_commitment = compute_coin_commitment(
+        &recipient_puzzle,
+        amount,
+        &serial_number,
+        &serial_randomness,
+    );
+
+    assert_eq!(
+        commitments[0], expected_commitment,
+        "commitment mismatch"
+    );
+
+    println!("✓ CREATE_COIN private mode working");
+    println!("  coin_commitment: {}", hex::encode(commitments[0]));
+}
+
+#[test]
+#[cfg(feature = "mock")]
+fn test_create_coin_multiple_outputs() {
+    // Generate random serials for 2 output coins
+    let serial1: [u8; 32] = rand::random();
+    let serial_rand1: [u8; 32] = rand::random();
+    let serial2: [u8; 32] = rand::random();
+    let serial_rand2: [u8; 32] = rand::random();
+
+    let recipient1 = [0x11u8; 32];
+    let recipient2 = [0x22u8; 32];
+    let amount1: u64 = 500;
+    let amount2: u64 = 300;
+
+    // Chialisp program creating 2 coins
+    let program = r#"
+        (mod (r1 a1 s1 sr1 r2 a2 s2 sr2)
+            (list
+                (list CREATE_COIN r1 a1 s1 sr1)
+                (list CREATE_COIN r2 a2 s2 sr2)))
+    "#;
+
+    let params = vec![
+        ProgramParameter::Bytes(recipient1.to_vec()),
+        ProgramParameter::Int(amount1),
+        ProgramParameter::Bytes(serial1.to_vec()),
+        ProgramParameter::Bytes(serial_rand1.to_vec()),
+        ProgramParameter::Bytes(recipient2.to_vec()),
+        ProgramParameter::Int(amount2),
+        ProgramParameter::Bytes(serial2.to_vec()),
+        ProgramParameter::Bytes(serial_rand2.to_vec()),
+    ];
+
+    let backend = MockBackend::new().expect("failed to create backend");
+    let result = backend
+        .prove_chialisp_program(program, &params)
+        .expect("proof generation failed");
+
+    let commitments = extract_coin_commitments(&result.proof_output)
+        .expect("failed to extract commitments");
+
+    // Should have exactly 2 commitments
+    assert_eq!(commitments.len(), 2, "expected 2 coin commitments");
+
+    // Verify both commitments
+    let expected1 = compute_coin_commitment(&recipient1, amount1, &serial1, &serial_rand1);
+    let expected2 = compute_coin_commitment(&recipient2, amount2, &serial2, &serial_rand2);
+
+    assert_eq!(commitments[0], expected1, "commitment 1 mismatch");
+    assert_eq!(commitments[1], expected2, "commitment 2 mismatch");
+
+    println!("✓ CREATE_COIN multiple outputs working");
+    println!("  commitment 1: {}", hex::encode(commitments[0]));
+    println!("  commitment 2: {}", hex::encode(commitments[1]));
+}
+
+#[test]
+#[cfg(feature = "mock")]
+fn test_create_coin_transparent_mode() {
+    // Test backward compatibility: 2-arg CREATE_COIN should pass through unchanged
+    let recipient = [0x33u8; 32];
+    let amount: u64 = 777;
+
+    let program = r#"
+        (mod (recipient amount)
+            (list (list CREATE_COIN recipient amount)))
+    "#;
+
+    let params = vec![
+        ProgramParameter::Bytes(recipient.to_vec()),
+        ProgramParameter::Int(amount),
+    ];
+
+    let backend = MockBackend::new().expect("failed to create backend");
+    let result = backend
+        .prove_chialisp_program(program, &params)
+        .expect("proof generation failed");
+
+    // Parse output to verify 2-arg format preserved
+    let conditions = deserialize_output_conditions(&result.proof_output.clvm_res.output)
+        .expect("failed to parse conditions");
+
+    assert_eq!(conditions.len(), 1, "expected 1 condition");
+    assert_eq!(conditions[0].opcode, 51, "expected CREATE_COIN opcode");
+    assert_eq!(conditions[0].args.len(), 2, "expected 2 args (transparent mode)");
+    assert_eq!(&conditions[0].args[0], &recipient.to_vec());
+
+    println!("✓ CREATE_COIN transparent mode (backward compatibility) working");
+}
+
+// Helper: compute coin_commitment
+fn compute_coin_commitment(
+    puzzle_hash: &[u8; 32],
+    amount: u64,
+    serial_number: &[u8; 32],
+    serial_randomness: &[u8; 32],
+) -> [u8; 32] {
+    // Compute serial_commitment
+    let serial_domain = b"clvm_zk_serial_v1.0";
+    let mut serial_data = [0u8; 83];
+    serial_data[..19].copy_from_slice(serial_domain);
+    serial_data[19..51].copy_from_slice(serial_number);
+    serial_data[51..83].copy_from_slice(serial_randomness);
+    let serial_commitment = hash_data(&serial_data);
+
+    // Compute coin_commitment
+    let coin_domain = b"clvm_zk_coin_v1.0";
+    let mut coin_data = [0u8; 89];
+    coin_data[..17].copy_from_slice(coin_domain);
+    coin_data[17..25].copy_from_slice(&amount.to_be_bytes());
+    coin_data[25..57].copy_from_slice(puzzle_hash);
+    coin_data[57..89].copy_from_slice(&serial_commitment);
+    hash_data(&coin_data)
+}
+
+// Helper: deserialize conditions for transparent mode test
+fn deserialize_output_conditions(
+    output: &[u8],
+) -> Result<Vec<clvm_zk_core::Condition>, &'static str> {
+    use clvm_zk_core::{ClvmParser, ClvmValue, Condition};
+
+    let mut parser = ClvmParser::new(output);
+    let parsed = parser.parse()?;
+
+    // Parse list of conditions
+    let mut conditions = Vec::new();
+    let mut current = &parsed;
+
+    loop {
+        match current {
+            ClvmValue::Atom(ref bytes) if bytes.is_empty() => break,
+            ClvmValue::Cons(ref first, ref rest) => {
+                // Parse condition
+                if let ClvmValue::Cons(ref opcode_val, ref args_val) = first.as_ref() {
+                    let opcode = match opcode_val.as_ref() {
+                        ClvmValue::Atom(ref bytes) if bytes.len() == 1 => bytes[0],
+                        _ => return Err("invalid opcode"),
+                    };
+
+                    // Extract args
+                    let mut args = Vec::new();
+                    let mut arg_current = args_val.as_ref();
+                    loop {
+                        match arg_current {
+                            ClvmValue::Atom(ref bytes) if bytes.is_empty() => break,
+                            ClvmValue::Cons(ref arg_first, ref arg_rest) => {
+                                if let ClvmValue::Atom(ref arg_bytes) = arg_first.as_ref() {
+                                    args.push(arg_bytes.clone());
+                                }
+                                arg_current = arg_rest.as_ref();
+                            }
+                            _ => return Err("invalid args structure"),
+                        }
+                    }
+
+                    conditions.push(Condition { opcode, args });
+                }
+                current = rest.as_ref();
+            }
+            _ => return Err("invalid list structure"),
+        }
+    }
+
+    Ok(conditions)
+}

--- a/tests/test_create_coin_privacy.rs
+++ b/tests/test_create_coin_privacy.rs
@@ -36,8 +36,8 @@ fn test_create_coin_private_mode() {
         .expect("proof generation failed");
 
     // Extract coin commitments from proof output
-    let commitments = extract_coin_commitments(&result.proof_output)
-        .expect("failed to extract commitments");
+    let commitments =
+        extract_coin_commitments(&result.proof_output).expect("failed to extract commitments");
 
     // Should have exactly 1 commitment
     assert_eq!(commitments.len(), 1, "expected 1 coin commitment");
@@ -50,10 +50,7 @@ fn test_create_coin_private_mode() {
         &serial_randomness,
     );
 
-    assert_eq!(
-        commitments[0], expected_commitment,
-        "commitment mismatch"
-    );
+    assert_eq!(commitments[0], expected_commitment, "commitment mismatch");
 
     println!("✓ CREATE_COIN private mode working");
     println!("  coin_commitment: {}", hex::encode(commitments[0]));
@@ -97,8 +94,8 @@ fn test_create_coin_multiple_outputs() {
         .prove_chialisp_program(program, &params)
         .expect("proof generation failed");
 
-    let commitments = extract_coin_commitments(&result.proof_output)
-        .expect("failed to extract commitments");
+    let commitments =
+        extract_coin_commitments(&result.proof_output).expect("failed to extract commitments");
 
     // Should have exactly 2 commitments
     assert_eq!(commitments.len(), 2, "expected 2 coin commitments");
@@ -143,7 +140,11 @@ fn test_create_coin_transparent_mode() {
 
     assert_eq!(conditions.len(), 1, "expected 1 condition");
     assert_eq!(conditions[0].opcode, 51, "expected CREATE_COIN opcode");
-    assert_eq!(conditions[0].args.len(), 2, "expected 2 args (transparent mode)");
+    assert_eq!(
+        conditions[0].args.len(),
+        2,
+        "expected 2 args (transparent mode)"
+    );
     assert_eq!(&conditions[0].args[0], &recipient.to_vec());
 
     println!("✓ CREATE_COIN transparent mode (backward compatibility) working");

--- a/tests/test_recursion.rs
+++ b/tests/test_recursion.rs
@@ -196,7 +196,7 @@ fn test_deep_recursion() {
     let fibonacci_source = r#"
         (mod (n)
             (defun fib (x)
-                (if (< x 2)
+                (if (> 2 x)
                     x
                     (+ (fib (- x 1)) (fib (- x 2)))))
             (fib n)

--- a/tests/test_simulator_create_coin.rs
+++ b/tests/test_simulator_create_coin.rs
@@ -1,8 +1,8 @@
 /// test simulator integration with 4-arg CREATE_COIN (output privacy)
 use clvm_zk::protocol::PrivateCoin;
 use clvm_zk::simulator::*;
-use clvm_zk_core::coin_commitment::{CoinSecrets, SerialCommitment};
 use clvm_zk_core::chialisp::compile_chialisp_template_hash_default;
+use clvm_zk_core::coin_commitment::{CoinSecrets, SerialCommitment};
 
 #[test]
 #[cfg(feature = "mock")]
@@ -36,8 +36,8 @@ fn test_create_and_spend_coins() {
     // alice sends 600 to bob, 300 to charlie (100 implicit fee)
     // bob will spend with an empty program
     let bob_program = "(mod () ())";
-    let bob_puzzle = compile_chialisp_template_hash_default(bob_program)
-        .expect("failed to compile bob program");
+    let bob_puzzle =
+        compile_chialisp_template_hash_default(bob_program).expect("failed to compile bob program");
 
     // charlie uses dummy puzzle for now (not spending)
     let charlie_puzzle = [0x33u8; 32];
@@ -116,10 +116,22 @@ fn test_create_and_spend_coins() {
     println!("  nullifiers: {}", tx.nullifiers.len());
 
     // verify simulator state
-    assert!(sim.has_nullifier(&tx.nullifiers[0]), "alice's nullifier should be tracked");
-    assert!(sim.get_coin_info(&alice_serial_num).is_none(), "alice's coin should be spent");
-    assert!(sim.get_coin_info(&bob_serial).is_some(), "bob's coin should exist");
-    assert!(sim.get_coin_info(&charlie_serial).is_some(), "charlie's coin should exist");
+    assert!(
+        sim.has_nullifier(&tx.nullifiers[0]),
+        "alice's nullifier should be tracked"
+    );
+    assert!(
+        sim.get_coin_info(&alice_serial_num).is_none(),
+        "alice's coin should be spent"
+    );
+    assert!(
+        sim.get_coin_info(&bob_serial).is_some(),
+        "bob's coin should exist"
+    );
+    assert!(
+        sim.get_coin_info(&charlie_serial).is_some(),
+        "charlie's coin should exist"
+    );
 
     println!("✓ coins tracked in simulator");
 
@@ -129,14 +141,24 @@ fn test_create_and_spend_coins() {
         vec![],
     );
 
-    assert!(result2.is_ok(), "bob should be able to spend his coin: {:?}", result2.err());
+    assert!(
+        result2.is_ok(),
+        "bob should be able to spend his coin: {:?}",
+        result2.err()
+    );
     let tx2 = result2.unwrap();
 
     println!("✓ bob spent his coin");
     println!("  tx: {}", hex::encode(tx2.id));
 
-    assert!(sim.get_coin_info(&bob_serial).is_none(), "bob's coin should be spent");
-    assert!(sim.get_coin_info(&charlie_serial).is_some(), "charlie's coin still exists");
+    assert!(
+        sim.get_coin_info(&bob_serial).is_none(),
+        "bob's coin should be spent"
+    );
+    assert!(
+        sim.get_coin_info(&charlie_serial).is_some(),
+        "charlie's coin still exists"
+    );
 
     println!("✓ full create → spend cycle working");
 }
@@ -155,8 +177,8 @@ fn test_create_coin_adds_to_merkle_tree() {
     "#;
 
     // compute actual puzzle hash for alice's coin
-    let puzzle_hash = compile_chialisp_template_hash_default(program)
-        .expect("failed to compile program");
+    let puzzle_hash =
+        compile_chialisp_template_hash_default(program).expect("failed to compile program");
 
     let (alice_coin, alice_secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
 
@@ -200,7 +222,10 @@ fn test_create_coin_adds_to_merkle_tree() {
     assert!(result.is_ok(), "spend should succeed: {:?}", result.err());
     let tx = result.unwrap();
 
-    println!("✓ spend succeeded, created transaction {}", hex::encode(tx.id));
+    println!(
+        "✓ spend succeeded, created transaction {}",
+        hex::encode(tx.id)
+    );
     println!("  nullifiers: {}", tx.nullifiers.len());
     println!("  spend bundles: {}", tx.spend_bundles.len());
 
@@ -227,8 +252,8 @@ fn test_create_coin_transparent_mode() {
     "#;
 
     // compute actual puzzle hash
-    let puzzle_hash = compile_chialisp_template_hash_default(program)
-        .expect("failed to compile program");
+    let puzzle_hash =
+        compile_chialisp_template_hash_default(program).expect("failed to compile program");
 
     let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 2000);
 
@@ -247,7 +272,11 @@ fn test_create_coin_transparent_mode() {
 
     let result = sim.spend_coins_with_params(vec![(coin, program.to_string(), params, secrets)]);
 
-    assert!(result.is_ok(), "transparent mode should work: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "transparent mode should work: {:?}",
+        result.err()
+    );
 
     println!("✓ transparent mode (2-arg CREATE_COIN) working");
 }

--- a/tests/test_simulator_create_coin.rs
+++ b/tests/test_simulator_create_coin.rs
@@ -1,0 +1,253 @@
+/// test simulator integration with 4-arg CREATE_COIN (output privacy)
+use clvm_zk::protocol::PrivateCoin;
+use clvm_zk::simulator::*;
+use clvm_zk_core::coin_commitment::{CoinSecrets, SerialCommitment};
+use clvm_zk_core::chialisp::compile_chialisp_template_hash_default;
+
+#[test]
+#[cfg(feature = "mock")]
+fn test_create_and_spend_coins() {
+    let mut sim = CLVMZkSimulator::new();
+
+    // program that creates 2 new coins
+    let alice_program = r#"
+        (mod (puzzle1 puzzle2 serial1 rand1 serial2 rand2)
+            (list
+                (list CREATE_COIN puzzle1 600 serial1 rand1)
+                (list CREATE_COIN puzzle2 300 serial2 rand2)))
+    "#;
+
+    // compute actual puzzle hash for alice's coin
+    let puzzle_hash = compile_chialisp_template_hash_default(alice_program)
+        .expect("failed to compile alice program");
+
+    let (alice_coin, alice_secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
+
+    sim.add_coin(
+        alice_coin.clone(),
+        &alice_secrets,
+        CoinMetadata {
+            owner: "alice".to_string(),
+            coin_type: CoinType::Regular,
+            notes: "genesis".to_string(),
+        },
+    );
+
+    // alice sends 600 to bob, 300 to charlie (100 implicit fee)
+    // bob will spend with an empty program
+    let bob_program = "(mod () ())";
+    let bob_puzzle = compile_chialisp_template_hash_default(bob_program)
+        .expect("failed to compile bob program");
+
+    // charlie uses dummy puzzle for now (not spending)
+    let charlie_puzzle = [0x33u8; 32];
+
+    // generate new coins for bob and charlie
+    let bob_serial: [u8; 32] = rand::random();
+    let bob_rand: [u8; 32] = rand::random();
+    let bob_secrets = CoinSecrets::new(bob_serial, bob_rand);
+    let bob_serial_commitment = SerialCommitment::compute(
+        &bob_serial,
+        &bob_rand,
+        clvm_zk::crypto_utils::hash_data_default,
+    );
+    let bob_coin = PrivateCoin {
+        puzzle_hash: bob_puzzle,
+        amount: 600,
+        serial_commitment: bob_serial_commitment,
+    };
+
+    let charlie_serial: [u8; 32] = rand::random();
+    let charlie_rand: [u8; 32] = rand::random();
+    let charlie_secrets = CoinSecrets::new(charlie_serial, charlie_rand);
+    let charlie_serial_commitment = SerialCommitment::compute(
+        &charlie_serial,
+        &charlie_rand,
+        clvm_zk::crypto_utils::hash_data_default,
+    );
+    let charlie_coin = PrivateCoin {
+        puzzle_hash: charlie_puzzle,
+        amount: 300,
+        serial_commitment: charlie_serial_commitment,
+    };
+
+    let params = vec![
+        clvm_zk::ProgramParameter::Bytes(bob_puzzle.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(charlie_puzzle.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(bob_serial.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(bob_rand.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(charlie_serial.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(charlie_rand.to_vec()),
+    ];
+
+    let output_coins = vec![
+        (
+            bob_coin.clone(),
+            bob_secrets.clone(),
+            CoinMetadata {
+                owner: "bob".to_string(),
+                coin_type: CoinType::Regular,
+                notes: "payment from alice".to_string(),
+            },
+        ),
+        (
+            charlie_coin.clone(),
+            charlie_secrets.clone(),
+            CoinMetadata {
+                owner: "charlie".to_string(),
+                coin_type: CoinType::Regular,
+                notes: "payment from alice".to_string(),
+            },
+        ),
+    ];
+
+    // spend alice's coin, creating bob's and charlie's coins
+    let alice_serial_num = alice_secrets.serial_number;
+    let result = sim.spend_coins_with_params_and_outputs(
+        vec![(alice_coin, alice_program.to_string(), params, alice_secrets)],
+        output_coins,
+    );
+
+    assert!(result.is_ok(), "spend should succeed: {:?}", result.err());
+    let tx = result.unwrap();
+
+    println!("✓ alice → bob(600) + charlie(300)");
+    println!("  tx: {}", hex::encode(tx.id));
+    println!("  nullifiers: {}", tx.nullifiers.len());
+
+    // verify simulator state
+    assert!(sim.has_nullifier(&tx.nullifiers[0]), "alice's nullifier should be tracked");
+    assert!(sim.get_coin_info(&alice_serial_num).is_none(), "alice's coin should be spent");
+    assert!(sim.get_coin_info(&bob_serial).is_some(), "bob's coin should exist");
+    assert!(sim.get_coin_info(&charlie_serial).is_some(), "charlie's coin should exist");
+
+    println!("✓ coins tracked in simulator");
+
+    // now bob spends his coin
+    let result2 = sim.spend_coins_with_params_and_outputs(
+        vec![(bob_coin, bob_program.to_string(), vec![], bob_secrets)],
+        vec![],
+    );
+
+    assert!(result2.is_ok(), "bob should be able to spend his coin: {:?}", result2.err());
+    let tx2 = result2.unwrap();
+
+    println!("✓ bob spent his coin");
+    println!("  tx: {}", hex::encode(tx2.id));
+
+    assert!(sim.get_coin_info(&bob_serial).is_none(), "bob's coin should be spent");
+    assert!(sim.get_coin_info(&charlie_serial).is_some(), "charlie's coin still exists");
+
+    println!("✓ full create → spend cycle working");
+}
+
+#[test]
+#[cfg(feature = "mock")]
+fn test_create_coin_adds_to_merkle_tree() {
+    let mut sim = CLVMZkSimulator::new();
+
+    // program that creates 2 new coins using 4-arg CREATE_COIN
+    let program = r#"
+        (mod (puzzle1 puzzle2 serial1 rand1 serial2 rand2)
+            (list
+                (list CREATE_COIN puzzle1 500 serial1 rand1)
+                (list CREATE_COIN puzzle2 300 serial2 rand2)))
+    "#;
+
+    // compute actual puzzle hash for alice's coin
+    let puzzle_hash = compile_chialisp_template_hash_default(program)
+        .expect("failed to compile program");
+
+    let (alice_coin, alice_secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 1000);
+
+    sim.add_coin(
+        alice_coin.clone(),
+        &alice_secrets,
+        CoinMetadata {
+            owner: "alice".to_string(),
+            coin_type: CoinType::Regular,
+            notes: "genesis".to_string(),
+        },
+    );
+
+    // recipient puzzle hashes
+    let puzzle1 = [0x22u8; 32];
+    let puzzle2 = [0x33u8; 32];
+
+    // generate random serials for output coins
+    let serial1: [u8; 32] = rand::random();
+    let rand1: [u8; 32] = rand::random();
+    let serial2: [u8; 32] = rand::random();
+    let rand2: [u8; 32] = rand::random();
+
+    let params = vec![
+        clvm_zk::ProgramParameter::Bytes(puzzle1.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(puzzle2.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(serial1.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(rand1.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(serial2.to_vec()),
+        clvm_zk::ProgramParameter::Bytes(rand2.to_vec()),
+    ];
+
+    // spend alice's coin, creating 2 new coins
+    let result = sim.spend_coins_with_params(vec![(
+        alice_coin,
+        program.to_string(),
+        params,
+        alice_secrets,
+    )]);
+
+    assert!(result.is_ok(), "spend should succeed: {:?}", result.err());
+    let tx = result.unwrap();
+
+    println!("✓ spend succeeded, created transaction {}", hex::encode(tx.id));
+    println!("  nullifiers: {}", tx.nullifiers.len());
+    println!("  spend bundles: {}", tx.spend_bundles.len());
+
+    // verify nullifier was added
+    let alice_nullifier = tx.nullifiers[0];
+    assert!(
+        sim.has_nullifier(&alice_nullifier),
+        "nullifier should be in set"
+    );
+
+    println!("✓ simulator integration with 4-arg CREATE_COIN working");
+}
+
+#[test]
+#[cfg(feature = "mock")]
+#[ignore = "simulator only supports private coins, not transparent mode"]
+fn test_create_coin_transparent_mode() {
+    let mut sim = CLVMZkSimulator::new();
+
+    // program using 2-arg CREATE_COIN (transparent mode)
+    let program = r#"
+        (mod (puzzle)
+            (list (list CREATE_COIN puzzle 1000)))
+    "#;
+
+    // compute actual puzzle hash
+    let puzzle_hash = compile_chialisp_template_hash_default(program)
+        .expect("failed to compile program");
+
+    let (coin, secrets) = PrivateCoin::new_with_secrets(puzzle_hash, 2000);
+
+    sim.add_coin(
+        coin.clone(),
+        &secrets,
+        CoinMetadata {
+            owner: "test".to_string(),
+            coin_type: CoinType::Regular,
+            notes: "test".to_string(),
+        },
+    );
+
+    let puzzle = [0x55u8; 32];
+    let params = vec![clvm_zk::ProgramParameter::Bytes(puzzle.to_vec())];
+
+    let result = sim.spend_coins_with_params(vec![(coin, program.to_string(), params, secrets)]);
+
+    assert!(result.is_ok(), "transparent mode should work: {:?}", result.err());
+
+    println!("✓ transparent mode (2-arg CREATE_COIN) working");
+}


### PR DESCRIPTION

core changes:
  - transform 4-arg CREATE_COIN(puzzle, amount, serial, rand) → 1-arg CREATE_COIN(coin_commitment) inside zkvm
  - guest programs compute serial_commitment and coin_commitment before outputting conditions
  - proof outputs only commitments, hiding puzzle_hash and amounts from observers
  - simulator extracts commitments from proof outputs and adds to merkle tree

  opcode fixes:
  - align announcement opcodes with chia spec (60-63 instead of 74-77)
  - remove LessThan operator (use `(> b a)` instead per chia standard)
  - add REMARK(1), SendMessage(66), ReceiveMessage(67)

  nullifier update:
  - include amount in nullifier: hash(serial || program_hash || amount)
  - prevents same serial being reused for different amounts
