### PR TITLE
feat: CAT minting + nullifier v2 (PR5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,18 +1,49 @@
-# PR Breakdown Plan: stealth_addresses_new → main
+# Veil PR Implementation Plan
 
-**Goal:** Decompose PR #17 into 7 focused PRs merged in dependency order.
-**Net result:** After all 7 are merged, diff vs current `stealth_addresses_new` should be empty.
-**Source branch:** `stealth_addresses_new`
+**Project:** Privacy-preserving zkVM for Chialisp. WIP research, MIT licensed.
 **Target:** `main`
+**Current state (2026-03-29):** PRs 1–4 are complete and pushed. PRs 5 and 6+7 remain.
 
-## Background reading
+## Essential reading before starting
 
-- `CLAUDE.md` — project rules, dev tips, architecture invariants
+- `CLAUDE.md` — project rules, dev tips, architecture invariants (scope discipline, test-first, etc.)
 - `DOCUMENTATION.md` — protocol details: nullifiers, stealth addresses, CATs, simulator, CLVM opcodes
-- `VEIL_DIFFERENTIAL_REVIEW_2026-03-15.md` — security review of this branch. F-01 through F-04 referenced throughout this plan all come from that document. Read it before touching PRs 3–5.
-- PR #17 on GitHub (`stealth_addresses_new`) — original monolithic PR this plan decomposes
+- `.context/full-context.md` — complete architecture context: commitment scheme, TAIL flow, ring spend, settlement
+- `.context/issues.md` — all known bugs and coverage gaps; cross-reference when implementing tests
 
-## Key concepts for PRs 3–5
+## Codebase orientation
+
+```
+clvm_zk_core/src/     — no_std core: types, commitments, merkle, CLVM eval (shared by host + guest)
+src/                  — host: ClvmZkProver facade, simulator, protocol, wallet, CLI
+backends/mock/        — mock backend: full logic, no ZK (used for all tests via `cargo test-mock`)
+backends/risc0/guest/ — RISC-0 zkVM guest: the actual ZK circuit
+backends/sp1/program/ — SP1 zkVM guest: mirrors risc0 guest
+```
+
+**How proof generation works (critical for PR5):**
+1. CLI calls `state.simulator.spend_coins(...)` or `simulator.mint_cat(...)` (new)
+2. Simulator calls `Spender::create_spend_with_serial(...)` from `src/protocol/spender.rs`
+3. Spender calls `ClvmZkProver::prove_with_serial_commitment(...)` — a static method in `src/lib.rs`
+4. `ClvmZkProver` builds an `Input` struct and calls `backend.prove_with_input(input)`
+5. Backend (mock/risc0/sp1) executes the circuit and returns `ZKClvmResult { proof_output, proof_bytes }`
+
+For Mint: same chain, but use `ClvmZkProver::prove_with_input(Input { coin_mode: CoinMode::Mint(mint_data), ... })` directly (no existing `Spender` method for mint yet — add one or call prover directly from simulator).
+
+**Key types (all in `clvm_zk_core/src/types.rs`):**
+- `CoinMode` — `Execute` | `Spend(SerialCommitmentData)` | `Mint(MintData)` — exclusively selects proof type
+- `MintData` — contains `tail_source`, `tail_params`, `output_puzzle_hash`, `output_amount`, `output_serial`, `output_rand`, `genesis_coin: Option<GenesisSpend>`
+- `GenesisSpend` — serial, randomness, puzzle_hash, amount, merkle_path, merkle_root, leaf_index for the genesis coin
+- `ProofOutput` — what the guest commits: `program_hash`, `nullifiers: Vec<[u8;32]>`, `clvm_res`, `public_values: Vec<Vec<u8>>`
+- `SimulatorError` — defined at `src/simulator.rs:775`: `DoubleSpend`, `ProgramHashMismatch`, `ProofGeneration`, `TestFailed`, `Protocol`
+
+**Test command aliases (defined in `.cargo/config.toml`):**
+```
+cargo test-mock    — runs all tests with mock backend (fast, no ZK)
+cargo run-risc0    — runs with real RISC-0 proofs (slow, needs --release)
+```
+
+## Key concepts (read before touching guest code in PR5)
 
 **TAIL program:** a Chialisp program that controls who can mint or melt a CAT asset. Its SHA256 hash is the asset's identifier (`tail_hash`). A coin's `tail_hash` is permanently bound at creation — you can't substitute a different TAIL program at spend time without detection.
 
@@ -29,16 +60,20 @@
 | PR | Branch | Status | Notes |
 |----|--------|--------|-------|
 | 1 | `pr/01-core-types` | ✅ merged PR #20 | |
-| 2 | `pr/02-simulator-migration` | ☐ todo | |
-| 3 | `pr/03-offer-fixes` | ☐ todo | |
-| 4 | `pr/04-stealth-nonce-encryption` | ☐ todo | |
-| 5 | `pr/05-cat-minting` | ☐ todo | cli.rs hunk split needed |
-| 6 | `pr/06-e2e-tests` | ☐ todo | |
-| 7 | `pr/07-examples-docs` | ☐ todo | |
+| 2 | `pr/02-simulator-migration` | ✅ pushed | |
+| 3 | `pr/03-offer-fixes` | ✅ pushed | NM-001, FIX-02/05/06, offer indexing |
+| 4 | `pr/04-stealth-nonce-encryption` | ✅ pushed | x25519+ChaCha20Poly1305, FIX-04 |
+| 5 | `pr/05-cat-minting` | ✅ pushed | CoinMode::Mint, genesis nullifier, mint_cat, CLI, 6 tests |
+| 6+7 | `pr/06-e2e-docs` | ☐ todo | combined: nullifier v2, e2e tests, docs |
 
 ---
 
-## PR 1: Core types + security hardening
+> PRs 1–4 below are **complete and pushed** — documented for reference only.
+> Start implementation at [PR 5](#pr-5-cat-minting--guests--mock--cli--tests).
+
+---
+
+## PR 1: Core types + security hardening ✅ MERGED
 
 **Branch:** `pr/01-core-types`
 **Base:** `main`
@@ -62,7 +97,7 @@ cargo test-mock
 
 ---
 
-## PR 2: Simulator — SparseMerkleTree migration + settlement double-spend
+## PR 2: Simulator — SparseMerkleTree migration + settlement double-spend ✅ PUSHED
 
 **Branch:** `pr/02-simulator-migration`
 **Base:** `pr/01-core-types` (or main after PR 1 merged)
@@ -85,7 +120,7 @@ cargo test-mock --test test_settlement_api
 
 ---
 
-## PR 3: Offer system bugfixes
+## PR 3: Offer system bugfixes ✅ PUSHED
 
 **Branch:** `pr/03-offer-fixes`
 **Base:** `pr/02-simulator-migration` (or main after PR 2 merged)
@@ -114,7 +149,7 @@ cargo test-mock --test test_settlement_api
 
 ---
 
-## PR 4: Stealth address nonce encryption
+## PR 4: Stealth address nonce encryption ✅ PUSHED
 
 **Branch:** `pr/04-stealth-nonce-encryption`
 **Base:** `pr/03-offer-fixes` (or main after PR 3 merged)
@@ -142,96 +177,338 @@ cargo test-mock -- crypto_utils::tests
 
 ---
 
-## PR 5: CAT minting — guests + mock + CLI + tests
+## ~~PR 5: CAT minting — guests + mock + CLI + tests~~
 
 **Branch:** `pr/05-cat-minting`
-**Base:** `pr/04-stealth-nonce-encryption` (or main after PR 4 merged)
-**Depends on:** PR 1 (MintData/GenesisSpend types), PR 2 (simulator for tests)
-**Description:** Full CAT minting stack: zkVM guest mint mode, TAIL-on-delta authorization with F-01 security fix, mock backend parity, CLI mint command, and the minting test suite. See "Key concepts" above for TAIL-on-delta and ring spend semantics before touching guest code.
+**Base:** `pr/04-stealth-nonce-encryption`
+**Depends on:** PR 1 (MintData/GenesisSpend types), PR 4 (base branch)
 
-**Security context (read before editing guests):**
-- **F-01 fix** (`VEIL_DIFFERENTIAL_REVIEW_2026-03-15.md`): guests now call `assert_eq!(compiled_tail_hash, tail_hash)` after compiling `tail_source`. This prevents an attacker substituting a permissive TAIL for a restrictive one at spend time.
-- **Ring spend carve-out**: the original F-01 fix incorrectly added `else { panic!("CAT supply change requires tail_source") }`. This fires for ring spends (where `tail_source = None` and `total_input != total_output` by design). That `else` branch was removed — if `tail_source` is `None`, the TAIL block is simply skipped. Do not re-add it.
-- **Mock backend parity**: the mock backend previously skipped TAIL-on-delta entirely. It now mirrors the guest logic: verify `hash(tail_source) == tail_hash`, then execute the TAIL and check it returns truthy. This ensures tests that pass mock also pass the real guests.
+**Description:** Full CAT minting stack. `CoinMode::Mint` currently panics in all backends. This PR
+implements mint in mock, risc0, and sp1 — including genesis coin one-time-use enforcement.
 
-**Files:**
-- `backends/risc0/guest/src/main.rs` — mint mode (new `if mint_data.is_some()` branch at top of main), TAIL-on-delta block with F-01 `assert_eq!`, ring spend carve-out (no `else` panic)
-- `backends/sp1/program/src/main.rs` — identical to risc0 guest changes
-- `backends/mock/src/backend.rs` — capture `(total_input, total_output)` from `enforce_ring_balance`; add TAIL-on-delta check block; `None` arm is a no-op (not an error)
-- `src/lib.rs` — add `#[cfg(feature = "mock")] pub use clvm_zk_mock::MockBackend` so integration tests can access it
-- `tests/test_cat_minting.rs` — new file: 6 tests including `test_f01_tail_substitution_rejected_mock` (F-01 regression)
+### What Mint proves (in-guest)
 
-**cli.rs functions changed (apply only these hunks):**
-- `SimAction` enum — add `Mint { ... }` variant
-- `run_simulator_command` — add routing arm for `SimAction::Mint`
-- `mint_command` — entirely new function (~132 lines); uses dummy BLS/ECDSA verifiers for CLI pre-check (see issue #18 for why this is acceptable)
+1. Compile `tail_source` → verify `hash(bytecode) == tail_hash` (F-01 same TAIL-hash check as Spend)
+2. Execute TAIL with `tail_params` → assert `!is_clvm_nil(output)` (TAIL authorizes the mint)
+3. If `genesis_coin` present:
+   - Verify `serial_commitment = hash(serial || rand)`
+   - Verify `coin_commitment = hash(tail_hash || amount || puzzle_hash || serial_commitment)` matches merkle leaf
+   - Verify merkle proof (genesis coin is in tree)
+   - Compute `genesis_nullifier = SHA256("clvm_zk_genesis_v1.0" || genesis_serial_number || genesis_tail_hash)`
+   - Emit genesis_nullifier in `ProofOutput.nullifiers` — validator adds to nullifier set → prevents re-minting
+4. Compute output `serial_commitment = hash(output_serial || output_rand)`
+5. Compute output `coin_commitment = hash(tail_hash || output_amount || output_puzzle_hash || serial_commitment)`
+6. Emit: `ProofOutput { nullifiers: [genesis_nullifier?], public_values: [output_coin_commitment] }`
 
-**Do NOT touch in this PR:**
-- `offer_take_command` (PR 3)
-- `send_command`, `scan_command`, `faucet_command`, `wallet_command` (PR 4)
+Note: minted coin commitment goes in `public_values[0]` (not nullifiers) — it's an output not a spend.
+
+### enforce_ring_balance guard
+
+`enforce_ring_balance` checks `Σ(inputs) ≥ Σ(outputs)`. For Mint there's no input coin — balance
+is not applicable. Add a guard in both mock and guests:
+```rust
+if !matches!(inputs.coin_mode, CoinMode::Mint(_)) {
+    enforce_ring_balance(&inputs, &conditions)?;
+}
+```
+
+### Files
+
+- `clvm_zk_core/src/lib.rs` — add:
+  ```rust
+  pub const GENESIS_NULLIFIER_DOMAIN: &[u8] = b"clvm_zk_genesis_v1.0";
+  pub fn compute_genesis_nullifier<H>(hasher: H, serial: &[u8;32], tail_hash: &[u8;32]) -> [u8;32]
+  ```
+  Note: genesis nullifier intentionally binds `tail_hash` (unlike spend nullifier — see ZK-01 in PR6+7).
+
+- `backends/mock/src/backend.rs` — replace `CoinMode::Mint(_) => Err(...)` with full mint path (steps 1–6 above). Add `enforce_ring_balance` guard before Spend path.
+
+- `backends/risc0/guest/src/main.rs` — same mint logic using `risc0_hasher`. Add Mint guard before `enforce_ring_balance`. CoinMode::Mint arm replaces the existing `panic!`.
+
+- `backends/sp1/program/src/main.rs` — mirror risc0 guest changes.
+
+- `backends/risc0/src/lib.rs`, `backends/sp1/src/lib.rs` — remove the host-side guard that rejects `CoinMode::Mint` before reaching guest (no longer needed).
+
+- `src/simulator.rs` — add `mint_cat` method. **Do NOT add a `prover` parameter** — the simulator
+  uses `ClvmZkProver` static methods internally (see `spend_coins_with_params_and_outputs` as the
+  pattern, which calls `Spender::create_spend_with_serial` → `ClvmZkProver::prove_with_serial_commitment`).
+  For mint, call `ClvmZkProver::prove_with_input` directly with `CoinMode::Mint(mint_data)`:
+  ```rust
+  pub fn mint_cat(
+      &mut self,
+      tail_source: &str,
+      tail_params: Vec<ProgramParameter>,
+      output_puzzle_hash: [u8; 32],
+      output_puzzle_source: &str,   // needed to record WalletCoinWrapper.program
+      output_amount: u64,
+      output_serial: [u8; 32],
+      output_rand: [u8; 32],
+      genesis_coin: Option<GenesisSpend>,
+  ) -> Result<([u8; 32], [u8; 32]), SimulatorError>
+  // returns (coin_commitment, tail_hash)
+  ```
+  Implementation:
+  1. Compile `tail_source` → get `tail_hash` (`compile_chialisp_to_bytecode` from `clvm_zk_core`)
+  2. Build `MintData { tail_source, tail_params, output_puzzle_hash, output_amount, output_serial, output_rand, genesis_coin }`
+  3. Build `Input { chialisp_source: "(mod () ())", program_parameters: vec![], coin_mode: CoinMode::Mint(mint_data), tail_hash: Some(tail_hash), ... }`
+  4. Call `crate::ClvmZkProver::prove_with_input(input)` → `ZKClvmResult`
+  5. Extract `coin_commitment` from `proof_output.public_values[0]` (32 bytes)
+  6. Insert genesis nullifier (`proof_output.nullifiers[0]` if present) into `self.nullifier_set`
+  7. Compute `serial_commitment = compute_serial_commitment(hash_data_default, output_serial, output_rand)`
+  8. Insert new `CoinInfo` into `self.utxo_set` keyed by `serial_commitment`
+  9. Insert `coin_commitment` into `self.coin_tree` + update `commitment_to_index`
+  10. Return `(coin_commitment, tail_hash)`
+
+- `src/cli.rs` — two changes:
+
+  **Add `SimAction::Mint` variant** (follows the same clap pattern as `SimAction::Faucet`):
+  ```rust
+  /// Mint new CAT tokens using a TAIL program
+  Mint {
+      /// Wallet name to receive the minted coins
+      wallet: String,
+      /// TAIL program source (Chialisp). e.g. "(mod () 1)" for unlimited mint.
+      #[arg(long)]
+      tail: String,
+      /// Amount to mint
+      #[arg(long)]
+      amount: u64,
+      /// Wallet coin index of the genesis coin (optional, for single-issuance TAILs)
+      #[arg(long)]
+      genesis_coin: Option<usize>,
+  }
+  ```
+
+  **Add `mint_command` function** (add routing arm `SimAction::Mint { wallet, tail, amount, genesis_coin }` in `run_simulator_command`, calling `mint_command(data_dir, &wallet, &tail, amount, genesis_coin)`):
+  ```rust
+  fn mint_command(
+      data_dir: &Path,
+      wallet_name: &str,
+      tail_source: &str,
+      amount: u64,
+      genesis_coin_index: Option<usize>,
+  ) -> Result<(), ClvmZkError>
+  ```
+  Implementation:
+  1. Load `SimulatorState::load(data_dir)`
+  2. Check wallet exists (same error pattern as `faucet_command`)
+  3. Generate `output_serial` and `output_rand` via `rand::thread_rng().fill_bytes(...)`
+  4. Get wallet's standard puzzle: `create_faucet_puzzle(amount)` or reuse wallet's last puzzle type
+  5. If `genesis_coin_index` is Some: extract `GenesisSpend` from `wallet.coins[idx]`
+     - Need serial/randomness/puzzle_hash/amount/tail_hash from the stored `WalletCoinWrapper`
+     - Need merkle path: call `state.simulator.get_merkle_path_and_index(serial_commitment)`
+  6. Call `state.simulator.mint_cat(tail_source, vec![], output_puzzle_hash, puzzle_source, amount, output_serial, output_rand, genesis_coin_opt)`
+  7. Create `WalletCoinWrapper` for the minted coin with `tail_source: Some(tail_source.to_string())`
+  8. Push to `wallet.coins`
+  9. Call `state.save(data_dir)`
+  10. Print: `"minted {} CAT (tail: {}) → commitment {}"` with amount, hex(tail_hash), hex(coin_commitment)
+
+- `tests/test_cat_minting.rs` — new file:
+  - `test_mint_unlimited_tail` — `(mod () 1)` TAIL mints, commitment in `public_values[0]`
+  - `test_mint_genesis_nullifier` — genesis coin path: nullifier in `nullifiers[0]`
+  - `test_mint_genesis_prevents_remint` — second mint with same genesis → rejected (nullifier set)
+  - `test_mint_tail_nil_rejected` — TAIL returns nil → `Err`
+  - `test_mint_tail_hash_mismatch` — wrong tail_source (hash mismatch) → `Err`
+  - `test_mint_then_spend` — mint then spend the minted coin in same simulator session
 
 **Test commands:**
 ```
 cargo test-mock --test test_cat_minting
 cargo test-mock   # full suite must still pass
-cargo check --no-default-features --features mock,testing
 ```
 
 ---
 
-## PR 6: E2E risc0 test suite
+## PR 6+7 (combined): Nullifier v2, E2E tests, documentation
 
-**Branch:** `pr/06-e2e-tests`
-**Base:** `pr/05-cat-minting` (or main after PR 5 merged)
-**Depends on:** PR 5 (guests must have mint mode + TAIL-on-delta for tests to be valid)
-**Description:** Pure test addition, no production code changes. 8 end-to-end tests covering the full protocol stack with real ZK proofs.
+**Branch:** `pr/06-e2e-docs`
+**Base:** `pr/05-cat-minting`
+**Depends on:** PR 5 (CAT lifecycle test requires mint)
 
-**Files:**
-- `tests/test_e2e_risc0.rs` — 8 tests: XCH spend, CAT mint+spend, genesis mint, ring spend, offer, TAIL-on-delta melt, settlement (x2), F-01 substitution regression
-
-**Test:** `cargo test-risc0 --test test_e2e_risc0` (requires risc0 build; slow).
+**Description:** Three areas in one PR: (1) security fix from zkdocs review (nullifier missing
+`tail_hash` and domain), (2) E2E test suite closing all coverage gaps, (3) documentation.
 
 ---
 
-## PR 7: Examples, demos, docs, cleanup
+### Security Background: zkdocs Review Findings
 
-**Branch:** `pr/07-examples-docs`
-**Base:** `pr/06-e2e-tests` (or main after PR 6 merged)
-**Depends on:** nothing (no logic)
-**Description:** Non-code changes. Reviewed separately so they don't dilute security review of PRs 1–6.
+Reviewed Trail of Bits zkdocs (https://www.zkdocs.com/docs/zkdocs/) against Veil.
+
+**ZK-01 (HIGH): Nullifier missing `tail_hash` — cross-asset collision attack**
+
+Current `compute_nullifier` = `SHA256(serial_number || program_hash || amount)` — no domain
+separator, no asset type binding. An adversary who controls serial number selection can create a
+CAT coin with identical `(serial_number, program_hash, amount)` to a target XCH coin. Spending the
+CAT coin inserts the nullifier first, permanently blocking the XCH coin. In a multi-asset system
+this is a soundness hole.
+
+Also: `full-context.md` documents `"clvm_zk_nullifier_v1.0"` as a domain prefix — that domain does
+NOT exist in the current code. Documentation is wrong.
+
+Fix: new v2 scheme:
+```
+nullifier_v2 = SHA256("clvm_zk_nullifier_v2.0" || tail_hash || serial_number || program_hash || amount)
+```
+
+**ZK-02 (LOW): AGG_SIG_UNSAFE replay risk**
+
+Opcode 49 does not bind to coin context. Document in DOCUMENTATION.md. No code change.
+
+**ZK-03/04 (INFORMATIONAL):** SHA-256 commitments are sound. Fiat-Shamir handled by zkVM. No action.
+
+---
+
+### Part 1: Nullifier v2
+
+**Exact callsites to update** (verified by grep — these are ALL the callsites):
+```
+backends/mock/src/backend.rs:346      — primary coin nullifier in CoinMode::Spend arm
+backends/mock/src/backend.rs:421      — ring coin nullifier in additional_coins loop
+backends/risc0/guest/src/main.rs:285  — primary coin nullifier
+backends/risc0/guest/src/main.rs:381  — ring coin nullifier
+backends/sp1/program/src/main.rs:270  — primary coin nullifier
+backends/sp1/program/src/main.rs:366  — ring coin nullifier
+```
+The simulator does NOT call `compute_nullifier` — it consumes nullifiers from `proof_output.nullifiers`
+already computed by the backend. `src/cli.rs` also needs no change.
 
 **Files:**
-- `examples/cat_offer_demo.rs` — demo showing full CAT offer flow
-- `cat_offer_demo.sh` — shell demo script
-- `demo.sh` — shell demo script
-- `scripts/multi_cat_demo.sh` — multi-CAT demo
-- `README.md` — updated docs
-- `.gitignore` — add audit files
-- `Cargo.toml` — minor cleanup
+- `clvm_zk_core/src/lib.rs` — add alongside the existing `compute_nullifier`:
+  ```rust
+  pub const NULLIFIER_V2_DOMAIN: &[u8] = b"clvm_zk_nullifier_v2.0"; // 22 bytes
+  // domain(22) + tail(32) + serial(32) + program(32) + amount(8) = 126
+  pub const NULLIFIER_V2_DATA_SIZE: usize = 126;
 
-**Test commands:**
+  pub fn compute_nullifier_v2<H>(
+      hasher: H,
+      tail_hash: &[u8; 32],
+      serial_number: &[u8; 32],
+      program_hash: &[u8; 32],
+      amount: u64,
+  ) -> [u8; 32]
+  where H: Fn(&[u8]) -> [u8; 32]
+  ```
+  Also add `#[deprecated(note = "use compute_nullifier_v2 — v1 lacks tail_hash binding")]` to
+  `compute_nullifier`. Update imports in the 3 backend files.
+
+- `backends/mock/src/backend.rs` — at lines 346 and 421: change `compute_nullifier(` →
+  `compute_nullifier_v2(hash_data,` and add `&tail_hash,` as first arg after hasher.
+  Update import line 3 to include `compute_nullifier_v2`.
+
+- `backends/risc0/guest/src/main.rs` — at lines 285 and 381: same pattern, hasher = `risc0_hasher`,
+  `tail_hash = private_inputs.tail_hash.unwrap_or([0u8;32])` for primary coin,
+  `tail_hash = coin.tail_hash` for ring coins.
+  Update import line 10.
+
+- `backends/sp1/program/src/main.rs` — at lines 270 and 366: same as risc0 guest.
+  Update import line 9.
+
+**Tests in `tests/test_nullifier_v2.rs`:**
+- `test_v2_includes_tail_hash` — XCH and CAT coins with same serial/program/amount → DIFFERENT v2 nullifiers
+- `test_v2_domain_separates_from_v1` — v2 output ≠ v1 output for same inputs
+- `test_cross_asset_isolation` — mock backend: spending XCH coin does NOT block CAT coin with same serial
+
+---
+
+### Part 2: E2E Test Suite (coverage gap closure)
+
+**`tests/test_e2e_xch_lifecycle.rs`**
+Full XCH lifecycle: `faucet → send(A→B) → scan(B) → spend(B's coin) → verify nullifier + new output commitment`
+
+**`tests/test_e2e_cat_lifecycle.rs`**
+Full CAT lifecycle: `mint_cat(tail="(mod () 1)") → send_cat(A→B with stealth) → scan(B) → spend_cat`
+Asserts CAT nullifier ≠ XCH nullifier for same serial (v2 enforcement in action).
+
+**`tests/test_e2e_settlement.rs`**
+Settlement lifecycle: `wallet_a has XCH, wallet_b has CAT → offer_create → offer_take → 4 outputs verified`
+Post-settlement spend assertions (NM-001 regression guard):
+- maker_change coin passes `spend` without error
+- taker_change coin passes `spend` without error
+
+**`tests/test_e2e_cat_ring_spend.rs`**
+Currently untested path (see coverage gaps in issues.md):
+`mint 2 CAT coins with same tail → ring_spend(coin_a + coin_b → output_c)`
+Asserts TAIL run per-ring-coin, 2 nullifiers emitted, balance enforced.
+
+**`tests/test_simulator_serde.rs`**
+Addresses `rebuild_tree after deserialization` coverage gap:
+`5-coin simulator state → serde_json round-trip → rebuild_tree() → all proofs valid, root matches`
+
+---
+
+### Part 3: Documentation
+
+**`DOCUMENTATION.md`** — add section **Security Model**:
+
+```markdown
+## Security Model
+
+### Nullifier Scheme (v2)
+nullifier = SHA256("clvm_zk_nullifier_v2.0" || tail_hash || serial_number || program_hash || amount)
+
+The tail_hash binding is CRITICAL: without it an adversary with serial number control could
+pre-poison any XCH coin's nullifier slot by minting a CAT coin with identical parameters and
+spending it first. v1 lacked this domain and tail_hash binding — v1 is deprecated.
+
+### AGG_SIG_UNSAFE (opcode 49)
+Does NOT bind signature to coin context (coin ID, puzzle hash). A valid AGG_SIG_UNSAFE signature
+can be replayed to any coin using the same puzzle + public key. Use AGG_SIG_ME (opcode 50) in
+production puzzles requiring spend-specific authorization.
+
+### Commitment Scheme Trade-offs
+Serial/coin commitments use SHA-256. Sound for current use. Not homomorphic — no efficient range
+proofs. Pedersen commitments would unlock homomorphic properties at the cost of additional circuit
+complexity. Acceptable trade-off for v1.
+
+### Known Limitations (open issues)
+- Stealth payment coin (offer output) uses raw stealth hash as puzzle — not spendable via standard
+  flow until stealth-claim mechanism (PR8+)
+- CoinMode::Mint supports unlimited TAILs (`(mod () 1)`) — production TAILs should be signature-gated
 ```
-cargo check --no-default-features --features mock,testing
+
+**`DOCUMENTATION.md`** — add section **Protocol Version History**:
+
+| Field | v1 | v2 (current) | PR |
+|-------|----|--------------|----|
+| nullifier | SHA256(serial ‖ program ‖ amount) | SHA256(domain ‖ tail_hash ‖ serial ‖ program ‖ amount) | PR6+7 |
+| coin_commitment | SHA256("clvm_zk_coin_v2.0" ‖ ...) | unchanged | PR1 |
+| serial_commitment | SHA256("clvm_zk_serial_v1.0" ‖ ...) | unchanged | initial |
+
+**`DOCUMENTATION.md`** — update existing demo scripts / examples to show `--tail` flag for minting.
+
+---
+
+### Test commands
+```
+cargo test-mock                              # full mock suite (all 5 new test files)
+cargo test-mock --test test_nullifier_v2
+cargo test-mock --test test_e2e_xch_lifecycle
+cargo test-mock --test test_e2e_cat_lifecycle
+cargo test-mock --test test_e2e_settlement
+cargo test-mock --test test_e2e_cat_ring_spend
+cargo test-mock --test test_simulator_serde
 ```
 
 ---
 
 ## Implementation notes
 
-### Creating branches
-Each branch is created off the current `stealth_addresses_new` tip and then pruned down to only the files/hunks for that PR:
+### Branch creation (PR5, PR6+7)
 ```
 git fetch origin main:main
-git checkout -b pr/01-core-types main
-# apply only the relevant files via: git checkout stealth_addresses_new -- <files>
-# or apply specific hunks via: git diff main stealth_addresses_new -- <file> | git apply --include=<hunk>
-```
-
-### Verification after all 7 merged
-```
-git diff <final-merge-commit> stealth_addresses_new
-# should be empty (or only whitespace/ordering diffs)
+git checkout pr/04-stealth-nonce-encryption
+git checkout -b pr/05-cat-minting
+# ... implement PR5 ...
+git checkout pr/05-cat-minting
+git checkout -b pr/06-e2e-docs
+# ... implement PR6+7 ...
 ```
 
 ### Order matters
-PRs must be merged in order 1→7. Each PR's branch is based on the previous PR's merge commit (or rebased onto main after each merge).
+PRs must be merged in order 1→6+7. PR6+7 depends on PR5 (CAT lifecycle test requires mint).
+PR5 depends on PR4 (base branch and wallet tail_source field).
+
+### zkdocs reference
+https://www.zkdocs.com/docs/zkdocs/ — Trail of Bits ZK documentation.
+ZK-01 through ZK-04 findings above reference sections on nullifier schemes, Fiat-Shamir,
+hash-based commitments, and signature replay.

--- a/backends/mock/src/backend.rs
+++ b/backends/mock/src/backend.rs
@@ -1,8 +1,8 @@
 use clvm_zk_core::verify_ecdsa_signature_with_hasher;
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier,
-    compute_serial_commitment, create_veil_evaluator, enforce_ring_balance, is_clvm_nil,
-    parse_variable_length_amount, run_clvm_with_conditions, serialize_params_to_clvm,
+    compile_chialisp_to_bytecode, compute_coin_commitment, compute_genesis_nullifier,
+    compute_nullifier_v2, compute_serial_commitment, create_veil_evaluator, enforce_ring_balance,
+    is_clvm_nil, parse_variable_length_amount, run_clvm_with_conditions, serialize_params_to_clvm,
     verify_merkle_proof, ClvmResult, ClvmZkError, CoinMode, Condition, ProgramParameter,
     ProofOutput, ZKClvmResult, BLS_DST,
 };
@@ -242,9 +242,12 @@ impl MockBackend {
         // BALANCE ENFORCEMENT (critical security check)
         // verify sum(inputs) == sum(outputs) and tail_hash consistency
         // MUST run BEFORE CREATE_COIN transformation
-        enforce_ring_balance(&inputs, &conditions).map_err(|e| {
-            ClvmZkError::ProofGenerationFailed(format!("balance enforcement failed: {}", e))
-        })?;
+        // skipped for Mint: no input coin, balance enforced by TAIL program instead
+        if !matches!(inputs.coin_mode, CoinMode::Mint(_)) {
+            enforce_ring_balance(&inputs, &conditions).map_err(|e| {
+                ClvmZkError::ProofGenerationFailed(format!("balance enforcement failed: {}", e))
+            })?;
+        }
 
         validate_signature_conditions(&conditions)?;
         let tail_hash = inputs.tail_hash.unwrap_or([0u8; 32]);
@@ -252,7 +255,7 @@ impl MockBackend {
             transform_create_coin_conditions(&mut conditions, output_bytes, tail_hash)?;
 
         let clvm_output = ClvmResult {
-            output: final_output,
+            output: final_output.clone(),
             cost: 0,
         };
 
@@ -343,18 +346,136 @@ impl MockBackend {
                     }
                 }
 
-                Some(compute_nullifier(
+                Some(compute_nullifier_v2(
                     hash_data,
+                    &tail_hash,
                     &commitment_data.serial_number,
                     &program_hash,
                     commitment_data.amount,
                 ))
             }
             CoinMode::Execute => None,
-            CoinMode::Mint(_) => {
-                return Err(ClvmZkError::ProofGenerationFailed(
-                    "mint mode not yet implemented in mock backend".to_string(),
-                ))
+            CoinMode::Mint(mint_data) => {
+                // Step 1: compile tail_source and verify hash matches inputs.tail_hash
+                let (tail_bytecode, tail_program_hash) =
+                    compile_chialisp_to_bytecode(hash_data, &mint_data.tail_source).map_err(
+                        |e| {
+                            ClvmZkError::ProofGenerationFailed(format!(
+                                "TAIL compilation failed: {:?}",
+                                e
+                            ))
+                        },
+                    )?;
+
+                if let Some(expected_tail_hash) = inputs.tail_hash {
+                    if tail_program_hash != expected_tail_hash {
+                        return Err(ClvmZkError::ProofGenerationFailed(
+                            "tail_hash mismatch: tail_source does not compile to the committed tail_hash".to_string()
+                        ));
+                    }
+                }
+
+                // Step 2: execute TAIL with tail_params — must return truthy
+                let tail_args = serialize_params_to_clvm(&mint_data.tail_params);
+                let (tail_output, _) =
+                    run_clvm_with_conditions(&evaluator, &tail_bytecode, &tail_args, max_cost)
+                        .map_err(|e| {
+                            ClvmZkError::ProofGenerationFailed(format!(
+                                "TAIL execution failed: {:?}",
+                                e
+                            ))
+                        })?;
+                if is_clvm_nil(&tail_output) {
+                    return Err(ClvmZkError::ProofGenerationFailed(
+                        "TAIL authorization failed: TAIL returned nil — must return truthy to authorize mint".to_string(),
+                    ));
+                }
+
+                // Step 3: handle genesis coin (single-issuance enforcement)
+                let genesis_nullifier = if let Some(genesis) = &mint_data.genesis_coin {
+                    let computed_serial =
+                        compute_serial_commitment(hash_data, &genesis.serial_number, &genesis.serial_randomness);
+                    if computed_serial != genesis.serial_commitment {
+                        return Err(ClvmZkError::ProofGenerationFailed(
+                            "genesis coin: serial commitment verification failed".to_string(),
+                        ));
+                    }
+
+                    let computed_coin = compute_coin_commitment(
+                        hash_data,
+                        genesis.tail_hash,
+                        genesis.amount,
+                        &genesis.puzzle_hash,
+                        &computed_serial,
+                    );
+                    if computed_coin != genesis.coin_commitment {
+                        return Err(ClvmZkError::ProofGenerationFailed(
+                            "genesis coin: coin commitment verification failed".to_string(),
+                        ));
+                    }
+
+                    verify_merkle_proof(
+                        hash_data,
+                        computed_coin,
+                        &genesis.merkle_path,
+                        usize::try_from(genesis.leaf_index)
+                            .expect("genesis leaf_index exceeds usize"),
+                        genesis.merkle_root,
+                    )
+                    .map_err(|e| {
+                        ClvmZkError::ProofGenerationFailed(format!(
+                            "genesis coin merkle verification failed: {}",
+                            e
+                        ))
+                    })?;
+
+                    Some(compute_genesis_nullifier(
+                        hash_data,
+                        &genesis.serial_number,
+                        &genesis.tail_hash,
+                    ))
+                } else {
+                    None
+                };
+
+                // Steps 4-6: compute output serial_commitment and coin_commitment
+                let output_serial_commitment = compute_serial_commitment(
+                    hash_data,
+                    &mint_data.output_serial,
+                    &mint_data.output_rand,
+                );
+                let tail_hash = inputs.tail_hash.unwrap_or(tail_program_hash);
+                let output_coin_commitment = compute_coin_commitment(
+                    hash_data,
+                    tail_hash,
+                    mint_data.output_amount,
+                    &mint_data.output_puzzle_hash,
+                    &output_serial_commitment,
+                );
+
+                // Step 7: emit proof — genesis_nullifier in nullifiers, coin_commitment in public_values
+                let nullifiers = genesis_nullifier.map(|n| vec![n]).unwrap_or_default();
+                let proof_output = ProofOutput {
+                    program_hash,
+                    nullifiers,
+                    clvm_res: ClvmResult {
+                        output: final_output,
+                        cost: 0,
+                    },
+                    proof_type: 3, // Mint
+                    public_values: vec![output_coin_commitment.to_vec()],
+                };
+
+                let proof_bytes = borsh::to_vec(&proof_output).map_err(|e| {
+                    ClvmZkError::SerializationError(format!(
+                        "failed to serialize mint proof: {e}"
+                    ))
+                })?;
+
+                return Ok(ZKClvmResult {
+                    proof_output,
+                    proof_bytes,
+                });
             }
         };
 
@@ -418,8 +539,9 @@ impl MockBackend {
                     }
                 }
 
-                nullifiers.push(compute_nullifier(
+                nullifiers.push(compute_nullifier_v2(
                     hash_data,
+                    &coin.tail_hash,
                     &coin_data.serial_number,
                     &coin_program_hash,
                     coin_data.amount,

--- a/backends/risc0/guest/src/main.rs
+++ b/backends/risc0/guest/src/main.rs
@@ -7,10 +7,10 @@ use risc0_zkvm::guest::env;
 use risc0_zkvm::sha::{Impl, Sha256 as RiscSha256};
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier,
-    compute_serial_commitment, create_veil_evaluator, is_clvm_nil, parse_variable_length_amount,
-    run_clvm_with_conditions, serialize_params_to_clvm, verify_merkle_proof, ClvmResult, CoinMode,
-    Input, ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode, compute_coin_commitment, compute_genesis_nullifier,
+    compute_nullifier_v2, compute_serial_commitment, create_veil_evaluator, is_clvm_nil,
+    parse_variable_length_amount, run_clvm_with_conditions, serialize_params_to_clvm,
+    verify_merkle_proof, ClvmResult, CoinMode, Input, ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -154,8 +154,11 @@ fn main() {
     // ============================================================================
     // verify sum(inputs) == sum(outputs) and tail_hash consistency
     // MUST run BEFORE CREATE_COIN transformation (which replaces args)
-    clvm_zk_core::enforce_ring_balance(&private_inputs, &conditions)
-        .expect("balance enforcement failed");
+    // skipped for Mint: no input coin, balance enforced by TAIL program instead
+    if !matches!(private_inputs.coin_mode, CoinMode::Mint(_)) {
+        clvm_zk_core::enforce_ring_balance(&private_inputs, &conditions)
+            .expect("balance enforcement failed");
+    }
 
     // Transform CREATE_COIN conditions for output privacy
     let mut has_transformations = false;
@@ -282,17 +285,112 @@ fn main() {
                 );
             }
 
-            Some(compute_nullifier(
+            Some(compute_nullifier_v2(
                 risc0_hasher,
+                &tail_hash,
                 &commitment_data.serial_number,
                 &program_hash,
                 commitment_data.amount,
             ))
         }
         CoinMode::Execute => None,
-        // host-side guard in risc0/src/lib.rs prevents this from being reached;
-        // this arm is a secondary defense — the guest cannot produce a valid proof for Mint yet.
-        CoinMode::Mint(_) => panic!("mint mode not yet implemented in this guest version"),
+        CoinMode::Mint(mint_data) => {
+            // Step 1: compile tail_source and verify hash matches private_inputs.tail_hash
+            let (tail_bytecode, tail_program_hash) =
+                compile_chialisp_to_bytecode(risc0_hasher, &mint_data.tail_source)
+                    .expect("TAIL compilation failed");
+
+            if let Some(expected_tail_hash) = private_inputs.tail_hash {
+                assert_eq!(
+                    tail_program_hash, expected_tail_hash,
+                    "tail_hash mismatch: tail_source does not compile to the committed tail_hash"
+                );
+            }
+
+            // Step 2: execute TAIL — must return truthy to authorize mint
+            let tail_args = serialize_params_to_clvm(&mint_data.tail_params);
+            let (tail_output, _) =
+                run_clvm_with_conditions(&evaluator, &tail_bytecode, &tail_args, max_cost)
+                    .expect("TAIL execution failed");
+            assert!(
+                !is_clvm_nil(&tail_output),
+                "TAIL authorization failed: TAIL returned nil — must return truthy to authorize mint"
+            );
+
+            // Step 3: handle genesis coin (single-issuance enforcement)
+            let genesis_nullifier = if let Some(genesis) = &mint_data.genesis_coin {
+                let computed_serial = compute_serial_commitment(
+                    risc0_hasher,
+                    &genesis.serial_number,
+                    &genesis.serial_randomness,
+                );
+                assert_eq!(
+                    computed_serial, genesis.serial_commitment,
+                    "genesis coin: serial commitment verification failed"
+                );
+
+                let computed_coin = compute_coin_commitment(
+                    risc0_hasher,
+                    genesis.tail_hash,
+                    genesis.amount,
+                    &genesis.puzzle_hash,
+                    &computed_serial,
+                );
+                assert_eq!(
+                    computed_coin, genesis.coin_commitment,
+                    "genesis coin: coin commitment verification failed"
+                );
+
+                verify_merkle_proof(
+                    risc0_hasher,
+                    computed_coin,
+                    &genesis.merkle_path,
+                    usize::try_from(genesis.leaf_index)
+                        .expect("genesis leaf_index exceeds usize"),
+                    genesis.merkle_root,
+                )
+                .expect("genesis coin merkle verification failed");
+
+                Some(compute_genesis_nullifier(
+                    risc0_hasher,
+                    &genesis.serial_number,
+                    &genesis.tail_hash,
+                ))
+            } else {
+                None
+            };
+
+            // Steps 4-6: compute output serial_commitment and coin_commitment
+            let output_serial_commitment = compute_serial_commitment(
+                risc0_hasher,
+                &mint_data.output_serial,
+                &mint_data.output_rand,
+            );
+            let tail_hash = private_inputs.tail_hash.unwrap_or(tail_program_hash);
+            let output_coin_commitment = compute_coin_commitment(
+                risc0_hasher,
+                tail_hash,
+                mint_data.output_amount,
+                &mint_data.output_puzzle_hash,
+                &output_serial_commitment,
+            );
+
+            // Step 7: emit — genesis_nullifier in nullifiers, coin_commitment in public_values
+            let nullifiers = genesis_nullifier.map(|n| vec![n]).unwrap_or_default();
+            let end_cycles = env::cycle_count();
+            let total_cycles = end_cycles.saturating_sub(start_cycles);
+            env::commit(&ProofOutput {
+                program_hash,
+                nullifiers,
+                clvm_res: ClvmResult {
+                    output: final_output,
+                    cost: total_cycles,
+                },
+                proof_type: 3, // Mint
+                public_values: vec![output_coin_commitment.to_vec()],
+            });
+            return;
+        }
     };
 
     // collect nullifiers: primary coin + additional coins for ring spends
@@ -378,8 +476,9 @@ fn main() {
                 );
             }
 
-            nullifiers.push(compute_nullifier(
+            nullifiers.push(compute_nullifier_v2(
                 risc0_hasher,
+                &coin.tail_hash,
                 &coin_data.serial_number,
                 &coin_program_hash,
                 coin_data.amount,

--- a/backends/risc0/guest_settlement/src/main.rs
+++ b/backends/risc0/guest_settlement/src/main.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier,
+    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier_v2,
     compute_serial_commitment, create_veil_evaluator, is_clvm_nil, run_clvm_with_conditions,
     serialize_params_to_clvm, verify_merkle_proof, ProgramParameter,
 };
@@ -191,8 +191,9 @@ fn main() {
     // let commitments_cycles = env::cycle_count();
 
     // compute taker's nullifier
-    let taker_nullifier = compute_nullifier(
+    let taker_nullifier = compute_nullifier_v2(
         risc0_hasher,
+        &input.taker_tail_hash,
         &input.taker_coin.serial_number,
         &input.taker_coin.puzzle_hash,
         input.taker_coin.amount,

--- a/backends/risc0/src/lib.rs
+++ b/backends/risc0/src/lib.rs
@@ -116,14 +116,6 @@ impl Risc0Backend {
             }
         }
 
-        // host-side guard: reject CoinMode::Mint before reaching the guest.
-        // the guest panics on Mint (not yet implemented); this surfaces a clean error instead.
-        if matches!(inputs.coin_mode, CoinMode::Mint(_)) {
-            return Err(ClvmZkError::ProofGenerationFailed(
-                "mint mode not yet supported in risc0 backend".to_string(),
-            ));
-        }
-
         // host-side guard: CAT spend without tail_source produces an opaque guest panic.
         // surface a clean error here instead.
         let is_cat = inputs.tail_hash.map_or(false, |h| h != [0u8; 32]);

--- a/backends/sp1/program/src/main.rs
+++ b/backends/sp1/program/src/main.rs
@@ -6,10 +6,10 @@ extern crate alloc;
 use alloc::vec;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier,
-    compute_serial_commitment, create_veil_evaluator, is_clvm_nil, parse_variable_length_amount,
-    run_clvm_with_conditions, serialize_params_to_clvm, verify_merkle_proof, ClvmResult, CoinMode,
-    Input, ProofOutput, BLS_DST,
+    compile_chialisp_to_bytecode, compute_coin_commitment, compute_genesis_nullifier,
+    compute_nullifier_v2, compute_serial_commitment, create_veil_evaluator, is_clvm_nil,
+    parse_variable_length_amount, run_clvm_with_conditions, serialize_params_to_clvm,
+    verify_merkle_proof, ClvmResult, CoinMode, Input, ProofOutput, BLS_DST,
 };
 
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
@@ -139,8 +139,11 @@ fn main() {
     // ============================================================================
     // verify sum(inputs) == sum(outputs) and tail_hash consistency
     // MUST run BEFORE CREATE_COIN transformation (which replaces args)
-    clvm_zk_core::enforce_ring_balance(&private_inputs, &conditions)
-        .expect("balance enforcement failed");
+    // skipped for Mint: no input coin, balance enforced by TAIL program instead
+    if !matches!(private_inputs.coin_mode, CoinMode::Mint(_)) {
+        clvm_zk_core::enforce_ring_balance(&private_inputs, &conditions)
+            .expect("balance enforcement failed");
+    }
 
     // Transform CREATE_COIN conditions for output privacy
     let mut has_transformations = false;
@@ -267,17 +270,110 @@ fn main() {
                 );
             }
 
-            Some(compute_nullifier(
+            Some(compute_nullifier_v2(
                 sp1_hasher,
+                &tail_hash,
                 &commitment_data.serial_number,
                 &program_hash,
                 commitment_data.amount,
             ))
         }
         CoinMode::Execute => None,
-        // host-side guard in sp1/src/lib.rs prevents this from being reached;
-        // this arm is a secondary defense — the guest cannot produce a valid proof for Mint yet.
-        CoinMode::Mint(_) => panic!("mint mode not yet implemented in this guest version"),
+        CoinMode::Mint(mint_data) => {
+            // Step 1: compile tail_source and verify hash matches private_inputs.tail_hash
+            let (tail_bytecode, tail_program_hash) =
+                compile_chialisp_to_bytecode(sp1_hasher, &mint_data.tail_source)
+                    .expect("TAIL compilation failed");
+
+            if let Some(expected_tail_hash) = private_inputs.tail_hash {
+                assert_eq!(
+                    tail_program_hash, expected_tail_hash,
+                    "tail_hash mismatch: tail_source does not compile to the committed tail_hash"
+                );
+            }
+
+            // Step 2: execute TAIL — must return truthy to authorize mint
+            let tail_args = serialize_params_to_clvm(&mint_data.tail_params);
+            let (tail_output, _) =
+                run_clvm_with_conditions(&evaluator, &tail_bytecode, &tail_args, max_cost)
+                    .expect("TAIL execution failed");
+            assert!(
+                !is_clvm_nil(&tail_output),
+                "TAIL authorization failed: TAIL returned nil — must return truthy to authorize mint"
+            );
+
+            // Step 3: handle genesis coin (single-issuance enforcement)
+            let genesis_nullifier = if let Some(genesis) = &mint_data.genesis_coin {
+                let computed_serial = compute_serial_commitment(
+                    sp1_hasher,
+                    &genesis.serial_number,
+                    &genesis.serial_randomness,
+                );
+                assert_eq!(
+                    computed_serial, genesis.serial_commitment,
+                    "genesis coin: serial commitment verification failed"
+                );
+
+                let computed_coin = compute_coin_commitment(
+                    sp1_hasher,
+                    genesis.tail_hash,
+                    genesis.amount,
+                    &genesis.puzzle_hash,
+                    &computed_serial,
+                );
+                assert_eq!(
+                    computed_coin, genesis.coin_commitment,
+                    "genesis coin: coin commitment verification failed"
+                );
+
+                verify_merkle_proof(
+                    sp1_hasher,
+                    computed_coin,
+                    &genesis.merkle_path,
+                    usize::try_from(genesis.leaf_index)
+                        .expect("genesis leaf_index exceeds usize"),
+                    genesis.merkle_root,
+                )
+                .expect("genesis coin merkle verification failed");
+
+                Some(compute_genesis_nullifier(
+                    sp1_hasher,
+                    &genesis.serial_number,
+                    &genesis.tail_hash,
+                ))
+            } else {
+                None
+            };
+
+            // Steps 4-6: compute output serial_commitment and coin_commitment
+            let output_serial_commitment = compute_serial_commitment(
+                sp1_hasher,
+                &mint_data.output_serial,
+                &mint_data.output_rand,
+            );
+            let tail_hash = private_inputs.tail_hash.unwrap_or(tail_program_hash);
+            let output_coin_commitment = compute_coin_commitment(
+                sp1_hasher,
+                tail_hash,
+                mint_data.output_amount,
+                &mint_data.output_puzzle_hash,
+                &output_serial_commitment,
+            );
+
+            // Step 7: emit — genesis_nullifier in nullifiers, coin_commitment in public_values
+            let nullifiers = genesis_nullifier.map(|n| vec![n]).unwrap_or_default();
+            io::commit(&ProofOutput {
+                program_hash,
+                nullifiers,
+                clvm_res: ClvmResult {
+                    output: final_output,
+                    cost: 0,
+                },
+                proof_type: 3, // Mint
+                public_values: vec![output_coin_commitment.to_vec()],
+            });
+            return;
+        }
     };
 
     // collect nullifiers: primary coin + additional coins for ring spends
@@ -363,8 +459,9 @@ fn main() {
                 );
             }
 
-            nullifiers.push(compute_nullifier(
+            nullifiers.push(compute_nullifier_v2(
                 sp1_hasher,
+                &coin.tail_hash,
                 &coin_data.serial_number,
                 &coin_program_hash,
                 coin_data.amount,

--- a/backends/sp1/program_settlement/src/main.rs
+++ b/backends/sp1/program_settlement/src/main.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use clvm_zk_core::{
-    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier,
+    compile_chialisp_to_bytecode, compute_coin_commitment, compute_nullifier_v2,
     compute_serial_commitment, create_veil_evaluator, is_clvm_nil, run_clvm_with_conditions,
     serialize_params_to_clvm, verify_merkle_proof, ProgramParameter,
 };
@@ -177,8 +177,9 @@ fn main() {
     );
 
     // compute taker's nullifier
-    let taker_nullifier = compute_nullifier(
+    let taker_nullifier = compute_nullifier_v2(
         sp1_hasher,
+        &input.taker_tail_hash,
         &input.taker_coin.serial_number,
         &input.taker_coin.puzzle_hash,
         input.taker_coin.amount,

--- a/backends/sp1/src/lib.rs
+++ b/backends/sp1/src/lib.rs
@@ -134,14 +134,6 @@ impl Sp1Backend {
             }
         }
 
-        // host-side guard: reject CoinMode::Mint before reaching the guest.
-        // the guest panics on Mint (not yet implemented); this surfaces a clean error instead.
-        if matches!(inputs.coin_mode, CoinMode::Mint(_)) {
-            return Err(ClvmZkError::ProofGenerationFailed(
-                "mint mode not yet supported in sp1 backend".to_string(),
-            ));
-        }
-
         // host-side guard: CAT spend without tail_source produces an opaque guest panic.
         // surface a clean error here instead.
         let is_cat = inputs.tail_hash.map_or(false, |h| h != [0u8; 32]);

--- a/clvm_zk_core/src/lib.rs
+++ b/clvm_zk_core/src/lib.rs
@@ -957,6 +957,7 @@ where
 }
 
 /// compute nullifier: hash(serial_number || program_hash || amount)
+#[deprecated(note = "use compute_nullifier_v2 — v1 lacks tail_hash binding, enabling cross-asset collision attacks")]
 pub fn compute_nullifier<H>(
     hasher: H,
     serial_number: &[u8; 32],
@@ -971,6 +972,52 @@ where
     nullifier_data.extend_from_slice(program_hash);
     nullifier_data.extend_from_slice(&amount.to_be_bytes());
     hasher(&nullifier_data)
+}
+
+pub const NULLIFIER_V2_DOMAIN: &[u8] = b"clvm_zk_nullifier_v2.0"; // 22 bytes
+pub const NULLIFIER_V2_DATA_SIZE: usize = 126; // domain(22) + tail(32) + serial(32) + program(32) + amount(8)
+
+/// compute spend nullifier v2: hash(domain || tail_hash || serial_number || program_hash || amount)
+///
+/// the tail_hash binding is CRITICAL: without it an adversary with serial number control could
+/// pre-poison an XCH coin's nullifier slot by spending a CAT coin with identical parameters first.
+pub fn compute_nullifier_v2<H>(
+    hasher: H,
+    tail_hash: &[u8; 32],
+    serial_number: &[u8; 32],
+    program_hash: &[u8; 32],
+    amount: u64,
+) -> [u8; 32]
+where
+    H: Fn(&[u8]) -> [u8; 32],
+{
+    let mut data = [0u8; NULLIFIER_V2_DATA_SIZE];
+    data[..22].copy_from_slice(NULLIFIER_V2_DOMAIN);
+    data[22..54].copy_from_slice(tail_hash);
+    data[54..86].copy_from_slice(serial_number);
+    data[86..118].copy_from_slice(program_hash);
+    data[118..126].copy_from_slice(&amount.to_be_bytes());
+    hasher(&data)
+}
+
+pub const GENESIS_NULLIFIER_DOMAIN: &[u8] = b"clvm_zk_genesis_v1.0";
+pub const GENESIS_NULLIFIER_DATA_SIZE: usize = 84; // domain(20) + serial_number(32) + tail_hash(32)
+
+/// compute genesis nullifier: hash(domain || serial_number || tail_hash)
+/// binds tail_hash to prevent cross-asset nullifier collisions at mint time
+pub fn compute_genesis_nullifier<H>(
+    hasher: H,
+    serial_number: &[u8; 32],
+    tail_hash: &[u8; 32],
+) -> [u8; 32]
+where
+    H: Fn(&[u8]) -> [u8; 32],
+{
+    let mut data = [0u8; GENESIS_NULLIFIER_DATA_SIZE];
+    data[..20].copy_from_slice(GENESIS_NULLIFIER_DOMAIN);
+    data[20..52].copy_from_slice(serial_number);
+    data[52..84].copy_from_slice(tail_hash);
+    hasher(&data)
 }
 
 // ============================================================================

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -250,6 +250,20 @@ pub enum SimAction {
     /// List pending offers
     #[command(name = "offer-list")]
     OfferList,
+    /// Mint new CAT tokens using a TAIL program
+    Mint {
+        /// Wallet name to receive the minted coins
+        wallet: String,
+        /// TAIL program source (Chialisp). e.g. "(mod () 1)" for unlimited mint.
+        #[arg(long)]
+        tail: String,
+        /// Amount to mint
+        #[arg(long)]
+        amount: u64,
+        /// Wallet coin index of the genesis coin (optional, for single-issuance TAILs)
+        #[arg(long)]
+        genesis_coin: Option<usize>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1165,6 +1179,15 @@ fn run_simulator_command(data_dir: &Path, action: SimAction) -> Result<(), ClvmZ
         SimAction::OfferList => {
             offer_list_command(data_dir)?;
         }
+
+        SimAction::Mint {
+            wallet,
+            tail,
+            amount,
+            genesis_coin,
+        } => {
+            mint_command(data_dir, &wallet, &tail, amount, genesis_coin)?;
+        }
     }
 
     Ok(())
@@ -1258,6 +1281,143 @@ fn faucet_command(
     println!(
         "funded wallet '{}' with {} {} coins of {} each (total: {})",
         wallet_name, count, asset_str, amount, total_funded
+    );
+
+    Ok(())
+}
+
+fn mint_command(
+    data_dir: &Path,
+    wallet_name: &str,
+    tail_source: &str,
+    amount: u64,
+    genesis_coin_index: Option<usize>,
+) -> Result<(), ClvmZkError> {
+    let mut state = SimulatorState::load(data_dir)?;
+
+    if !state.wallets.contains_key(wallet_name) {
+        return Err(ClvmZkError::InvalidProgram(format!(
+            "wallet '{}' not found. create it first with: sim wallet {} create",
+            wallet_name, wallet_name
+        )));
+    }
+
+    // generate random output secrets
+    let mut output_serial = [0u8; 32];
+    let mut output_rand = [0u8; 32];
+    thread_rng().fill_bytes(&mut output_serial);
+    thread_rng().fill_bytes(&mut output_rand);
+
+    // output coin gets a faucet puzzle
+    let (puzzle_source, output_puzzle_hash) = create_faucet_puzzle(amount);
+
+    // extract genesis_coin if requested
+    let genesis_spend: Option<clvm_zk_core::GenesisSpend> = if let Some(idx) = genesis_coin_index {
+        let wallet = state.wallets.get(wallet_name).unwrap();
+        let unspent: Vec<&WalletCoinWrapper> =
+            wallet.coins.iter().filter(|c| !c.spent).collect();
+
+        if idx >= unspent.len() {
+            return Err(ClvmZkError::InvalidProgram(format!(
+                "genesis coin index {} out of range (0-{})",
+                idx,
+                unspent.len().saturating_sub(1)
+            )));
+        }
+        let genesis_wrapper = unspent[idx];
+        let private_coin = genesis_wrapper.to_private_coin();
+        let secrets = genesis_wrapper.secrets();
+
+        let (merkle_path, leaf_index) = state
+            .simulator
+            .get_merkle_path_and_index(&private_coin)
+            .ok_or_else(|| {
+                ClvmZkError::InvalidProgram("genesis coin not found in merkle tree".to_string())
+            })?;
+
+        let merkle_root = state.simulator.get_merkle_root();
+
+        let serial_commitment_bytes = *private_coin.serial_commitment.as_bytes();
+        let coin_commitment = clvm_zk_core::coin_commitment::CoinCommitment::compute(
+            &private_coin.tail_hash,
+            private_coin.amount,
+            &private_coin.puzzle_hash,
+            &private_coin.serial_commitment,
+            crate::crypto_utils::hash_data_default,
+        );
+
+        Some(clvm_zk_core::GenesisSpend {
+            serial_number: secrets.serial_number,
+            serial_randomness: secrets.serial_randomness,
+            puzzle_hash: private_coin.puzzle_hash,
+            amount: private_coin.amount,
+            tail_hash: private_coin.tail_hash,
+            serial_commitment: serial_commitment_bytes,
+            coin_commitment: coin_commitment.0,
+            merkle_path,
+            merkle_root,
+            leaf_index: leaf_index as u64,
+        })
+    } else {
+        None
+    };
+
+    // call mint_cat on simulator
+    let (coin_commitment, confirmed_tail_hash) = state
+        .simulator
+        .mint_cat(
+            tail_source,
+            vec![],
+            output_puzzle_hash,
+            &puzzle_source,
+            amount,
+            output_serial,
+            output_rand,
+            genesis_spend,
+        )
+        .map_err(|e| ClvmZkError::InvalidProgram(format!("mint failed: {}", e)))?;
+
+    // construct WalletPrivateCoin with the known secrets
+    let serial_commitment = clvm_zk_core::coin_commitment::SerialCommitment::compute(
+        &output_serial,
+        &output_rand,
+        crate::crypto_utils::hash_data_default,
+    );
+    let private_coin = crate::protocol::PrivateCoin::new_with_tail(
+        output_puzzle_hash,
+        amount,
+        serial_commitment,
+        confirmed_tail_hash,
+    );
+    let secrets = clvm_zk_core::coin_commitment::CoinSecrets::new(output_serial, output_rand);
+    let wallet_private_coin = crate::wallet::hd_wallet::WalletPrivateCoin {
+        coin: private_coin,
+        secrets,
+        account_index: state.wallets[wallet_name].account_index,
+        coin_index: 0,
+    };
+
+    let minted_wrapper = WalletCoinWrapper {
+        wallet_coin: wallet_private_coin,
+        program: puzzle_source,
+        spent: false,
+        tail_source: Some(tail_source.to_string()),
+    };
+
+    state
+        .wallets
+        .get_mut(wallet_name)
+        .unwrap()
+        .coins
+        .push(minted_wrapper);
+
+    state.save(data_dir)?;
+
+    println!(
+        "minted {} CAT (tail: {}) → commitment {}",
+        amount,
+        hex::encode(confirmed_tail_hash),
+        hex::encode(coin_commitment)
     );
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,28 @@ impl ClvmZkProver {
         }
     }
 
+    /// prove with a pre-built Input struct (used by mint and other direct-construction paths)
+    #[allow(clippy::needless_return)]
+    pub fn prove_with_input(input: Input) -> Result<ZKClvmResult, ClvmZkError> {
+        #[cfg(feature = "risc0")]
+        {
+            let backend = clvm_zk_risc0::Risc0Backend::new()?;
+            return backend.prove_with_input(input);
+        }
+
+        #[cfg(feature = "sp1")]
+        {
+            let backend = clvm_zk_sp1::Sp1Backend::new()?;
+            return backend.prove_with_input(input);
+        }
+
+        #[cfg(feature = "mock")]
+        {
+            let backend = clvm_zk_mock::MockBackend::new()?;
+            backend.prove_with_input(input)
+        }
+    }
+
     /// aggregate multiple proofs into a single recursive proof
     ///
     /// this compresses N transaction proofs into 1 proof while preserving

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -178,6 +178,7 @@ impl CLVMZkSimulator {
             created_at_height: self.block_height,
             stealth_nonce: None,
             puzzle_source: None,
+            tail_source: None,
         };
 
         let coin_commitment = CoinCommitment::compute(
@@ -219,6 +220,7 @@ impl CLVMZkSimulator {
             created_at_height: self.block_height,
             stealth_nonce: Some(encrypted_nonce),
             puzzle_source: Some(puzzle_source),
+            tail_source: None,
         };
 
         let coin_commitment = CoinCommitment::compute(
@@ -334,6 +336,12 @@ impl CLVMZkSimulator {
                         SimulatorError::TestFailed("coin not found in merkle tree".to_string())
                     })?;
 
+                // for CAT coins, look up the stored tail_source so the backend can authorize
+                let coin_tail_source = self
+                    .utxo_set
+                    .get(&secrets.serial_number)
+                    .and_then(|info| info.tail_source.clone());
+
                 match Spender::create_spend_with_serial(
                     &coin,
                     &program,
@@ -342,7 +350,7 @@ impl CLVMZkSimulator {
                     merkle_path,
                     merkle_root,
                     leaf_index,
-                    None, // XCH spend: no TAIL required
+                    coin_tail_source,
                     vec![],
                 ) {
                     Ok(bundle) => {
@@ -459,6 +467,7 @@ impl CLVMZkSimulator {
                         created_at_height: self.block_height,
                         stealth_nonce: None,
                         puzzle_source: None,
+                        tail_source: None,
                     },
                 );
             }
@@ -473,6 +482,128 @@ impl CLVMZkSimulator {
         self.block_height += 1;
 
         Ok(tx)
+    }
+
+    /// mint new CAT tokens using a TAIL program
+    ///
+    /// calls ClvmZkProver::prove_with_input with CoinMode::Mint, then registers the minted
+    /// coin in the simulator state (merkle tree + utxo_set).
+    ///
+    /// returns (coin_commitment, tail_hash)
+    pub fn mint_cat(
+        &mut self,
+        tail_source: &str,
+        tail_params: Vec<crate::ProgramParameter>,
+        output_puzzle_hash: [u8; 32],
+        output_puzzle_source: &str,
+        output_amount: u64,
+        output_serial: [u8; 32],
+        output_rand: [u8; 32],
+        genesis_coin: Option<clvm_zk_core::GenesisSpend>,
+    ) -> Result<([u8; 32], [u8; 32]), SimulatorError> {
+        // Step 1: compile tail_source to get tail_hash
+        let (_, tail_hash) =
+            clvm_zk_core::compile_chialisp_to_bytecode(crate::crypto_utils::hash_data_default, tail_source)
+                .map_err(|e| {
+                    SimulatorError::ProofGeneration(format!("TAIL compilation failed: {:?}", e))
+                })?;
+
+        // Step 1b: pre-check genesis nullifier to prevent double-mint
+        if let Some(ref gen) = genesis_coin {
+            let genesis_nullifier = clvm_zk_core::compute_genesis_nullifier(
+                crate::crypto_utils::hash_data_default,
+                &gen.serial_number,
+                &gen.tail_hash,
+            );
+            if self.nullifier_set.contains(&genesis_nullifier) {
+                return Err(SimulatorError::DoubleSpend(hex::encode(genesis_nullifier)));
+            }
+        }
+
+        // Step 2: build MintData
+        let mint_data = clvm_zk_core::MintData {
+            tail_source: tail_source.to_string(),
+            tail_params,
+            output_puzzle_hash,
+            output_amount,
+            output_serial,
+            output_rand,
+            genesis_coin,
+        };
+
+        // Step 3: build Input with CoinMode::Mint
+        let input = crate::Input {
+            chialisp_source: "(mod () ())".to_string(),
+            program_parameters: vec![],
+            coin_mode: crate::CoinMode::Mint(mint_data),
+            tail_hash: Some(tail_hash),
+            tail_source: None,
+            tail_params: vec![],
+            additional_coins: None,
+        };
+
+        // Step 4: prove
+        let result = crate::ClvmZkProver::prove_with_input(input)
+            .map_err(|e| SimulatorError::ProofGeneration(format!("{}", e)))?;
+
+        // Step 5: extract coin_commitment from public_values[0]
+        let coin_commitment_vec = result.proof_output.public_values.first().ok_or_else(|| {
+            SimulatorError::ProofGeneration(
+                "mint proof missing coin_commitment in public_values[0]".to_string(),
+            )
+        })?;
+        if coin_commitment_vec.len() != 32 {
+            return Err(SimulatorError::ProofGeneration(
+                "coin_commitment must be 32 bytes".to_string(),
+            ));
+        }
+        let mut coin_commitment = [0u8; 32];
+        coin_commitment.copy_from_slice(coin_commitment_vec);
+
+        // Step 6: insert genesis nullifier if present
+        for nullifier in &result.proof_output.nullifiers {
+            self.nullifier_set.insert(*nullifier);
+        }
+
+        // Step 7: compute serial_commitment for UTXO keying
+        let serial_commitment = clvm_zk_core::compute_serial_commitment(
+            crate::crypto_utils::hash_data_default,
+            &output_serial,
+            &output_rand,
+        );
+
+        // Step 8: insert new coin into utxo_set
+        let private_coin = PrivateCoin::new_with_tail(
+            output_puzzle_hash,
+            output_amount,
+            clvm_zk_core::coin_commitment::SerialCommitment::from_bytes(serial_commitment),
+            tail_hash,
+        );
+        self.utxo_set.insert(
+            output_serial,
+            CoinInfo {
+                coin: private_coin,
+                metadata: CoinMetadata {
+                    owner: "mint".to_string(),
+                    coin_type: CoinType::Cat,
+                    notes: format!("minted CAT tail:{}", hex::encode(&tail_hash[..8])),
+                },
+                created_at_height: self.block_height,
+                stealth_nonce: None,
+                puzzle_source: Some(output_puzzle_source.to_string()),
+                tail_source: Some(tail_source.to_string()),
+            },
+        );
+
+        // Step 9: insert coin_commitment into merkle tree
+        let h = hasher();
+        let leaf_index = self.coin_tree.len();
+        self.coin_tree.insert(coin_commitment, h);
+        self.commitment_to_index.insert(coin_commitment, leaf_index);
+        self.merkle_leaves.push(coin_commitment);
+
+        // Step 10: return (coin_commitment, tail_hash)
+        Ok((coin_commitment, tail_hash))
     }
 
     pub fn has_nullifier(&self, nullifier: &[u8; 32]) -> bool {
@@ -735,6 +866,9 @@ pub struct CoinInfo {
     /// chialisp source for stealth coins (needed for spending)
     #[serde(default)]
     pub puzzle_source: Option<String>,
+    /// TAIL source for CAT coins (needed to re-authorize spends)
+    #[serde(default)]
+    pub tail_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/test_cat_minting.rs
+++ b/tests/test_cat_minting.rs
@@ -1,0 +1,374 @@
+/// CAT minting tests.
+///
+/// Verifies the full mint stack:
+///   1. Unlimited TAIL (mod () 1) mints a coin — commitment in public_values[0]
+///   2. Genesis coin path — nullifier in nullifiers[0]
+///   3. Genesis coin prevents re-minting (double-spend via nullifier set)
+///   4. TAIL returning nil → Err
+///   5. Wrong tail_source (hash mismatch) → Err
+///   6. Mint then spend the minted coin in same simulator session
+#[cfg(feature = "mock")]
+mod cat_minting {
+    use clvm_zk::simulator::{CLVMZkSimulator, CoinMetadata, CoinType};
+    use clvm_zk_core::coin_commitment::{CoinCommitment, CoinSecrets, SerialCommitment, XCH_TAIL};
+    use clvm_zk_core::merkle::SparseMerkleTree;
+    use clvm_zk_core::{
+        compile_chialisp_to_bytecode, compute_coin_commitment, compute_genesis_nullifier,
+        compute_serial_commitment, CoinMode, GenesisSpend, Input, MintData, ProgramParameter,
+    };
+    use clvm_zk_mock::MockBackend;
+    use sha2::{Digest, Sha256};
+
+    const TREE_DEPTH: usize = 20;
+
+    fn hash_data(data: &[u8]) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(data);
+        h.finalize().into()
+    }
+
+    fn rand_bytes() -> [u8; 32] {
+        use rand::RngCore;
+        let mut buf = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut buf);
+        buf
+    }
+
+    /// Build a minimal mint Input for a given tail_source, optionally with genesis.
+    fn build_mint_input(
+        tail_source: &str,
+        output_serial: [u8; 32],
+        output_rand: [u8; 32],
+        genesis_coin: Option<GenesisSpend>,
+    ) -> Input {
+        let (_, tail_hash) = compile_chialisp_to_bytecode(hash_data, tail_source)
+            .expect("tail compilation failed");
+
+        let output_puzzle_hash = hash_data(b"test_output_puzzle");
+
+        Input {
+            chialisp_source: "(mod () ())".to_string(),
+            program_parameters: vec![],
+            coin_mode: CoinMode::Mint(MintData {
+                tail_source: tail_source.to_string(),
+                tail_params: vec![],
+                output_puzzle_hash,
+                output_amount: 1000,
+                output_serial,
+                output_rand,
+                genesis_coin,
+            }),
+            tail_hash: Some(tail_hash),
+            tail_source: None,
+            tail_params: vec![],
+            additional_coins: None,
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Test 1: unlimited TAIL mints — coin_commitment in public_values[0]
+    // ────────────────────────────────────────────────────────────
+    #[test]
+    fn test_mint_unlimited_tail() {
+        let backend = MockBackend::new().unwrap();
+        let output_serial = rand_bytes();
+        let output_rand = rand_bytes();
+        let input = build_mint_input("(mod () 1)", output_serial, output_rand, None);
+
+        let result = backend.prove_with_input(input).expect("mint should succeed");
+
+        // coin_commitment must be in public_values[0]
+        assert_eq!(
+            result.proof_output.public_values.len(),
+            1,
+            "expected exactly 1 public value (coin_commitment)"
+        );
+        assert_eq!(
+            result.proof_output.public_values[0].len(),
+            32,
+            "coin_commitment must be 32 bytes"
+        );
+
+        // no genesis nullifier
+        assert!(
+            result.proof_output.nullifiers.is_empty(),
+            "no genesis nullifier expected for unlimited TAIL"
+        );
+
+        // verify the commitment matches what we'd compute locally
+        let (_, tail_hash) =
+            compile_chialisp_to_bytecode(hash_data, "(mod () 1)").unwrap();
+        let output_puzzle_hash = hash_data(b"test_output_puzzle");
+        let serial_commitment =
+            compute_serial_commitment(hash_data, &output_serial, &output_rand);
+        let expected_commitment = compute_coin_commitment(
+            hash_data,
+            tail_hash,
+            1000,
+            &output_puzzle_hash,
+            &serial_commitment,
+        );
+
+        let mut got = [0u8; 32];
+        got.copy_from_slice(&result.proof_output.public_values[0]);
+        assert_eq!(got, expected_commitment, "coin_commitment mismatch");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Test 2: genesis coin path — nullifier in nullifiers[0]
+    // ────────────────────────────────────────────────────────────
+    #[test]
+    fn test_mint_genesis_nullifier() {
+        // set up a tree with one genesis coin
+        let mut tree = SparseMerkleTree::new(TREE_DEPTH, hash_data);
+
+        let genesis_serial = rand_bytes();
+        let genesis_rand = rand_bytes();
+        let genesis_puzzle_hash = hash_data(b"genesis_puzzle");
+        let genesis_amount = 500u64;
+        let genesis_tail_hash = XCH_TAIL; // genesis is XCH
+
+        let serial_commitment =
+            compute_serial_commitment(hash_data, &genesis_serial, &genesis_rand);
+        let coin_commitment = compute_coin_commitment(
+            hash_data,
+            genesis_tail_hash,
+            genesis_amount,
+            &genesis_puzzle_hash,
+            &serial_commitment,
+        );
+        tree.insert(coin_commitment, hash_data);
+        let proof = tree.generate_proof(0, hash_data).unwrap();
+        let merkle_root = tree.root();
+
+        let genesis = GenesisSpend {
+            serial_number: genesis_serial,
+            serial_randomness: genesis_rand,
+            puzzle_hash: genesis_puzzle_hash,
+            amount: genesis_amount,
+            tail_hash: genesis_tail_hash,
+            serial_commitment,
+            coin_commitment,
+            merkle_path: proof.path,
+            merkle_root,
+            leaf_index: 0,
+        };
+
+        let backend = MockBackend::new().unwrap();
+        let output_serial = rand_bytes();
+        let output_rand = rand_bytes();
+        let input = build_mint_input("(mod () 1)", output_serial, output_rand, Some(genesis));
+
+        let result = backend.prove_with_input(input).expect("genesis mint should succeed");
+
+        // genesis nullifier must be in nullifiers[0]
+        assert_eq!(result.proof_output.nullifiers.len(), 1);
+        let expected_nullifier =
+            compute_genesis_nullifier(hash_data, &genesis_serial, &genesis_tail_hash);
+        assert_eq!(result.proof_output.nullifiers[0], expected_nullifier);
+
+        // coin_commitment still in public_values
+        assert_eq!(result.proof_output.public_values.len(), 1);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Test 3: same genesis coin → second mint must fail (nullifier set)
+    // ────────────────────────────────────────────────────────────
+    #[test]
+    fn test_mint_genesis_prevents_remint() {
+        let mut sim = CLVMZkSimulator::default();
+
+        // add genesis coin to simulator
+        let genesis_puzzle = "(mod () 1)".to_string();
+        let (genesis_coin, genesis_secrets) = clvm_zk::protocol::PrivateCoin::new_with_secrets(
+            clvm_zk_core::compile_chialisp_to_bytecode(
+                clvm_zk::crypto_utils::hash_data_default,
+                &genesis_puzzle,
+            )
+            .unwrap()
+            .1,
+            500,
+        );
+        sim.add_coin(
+            genesis_coin.clone(),
+            &genesis_secrets,
+            CoinMetadata {
+                owner: "tester".to_string(),
+                coin_type: CoinType::Regular,
+                notes: "genesis".to_string(),
+            },
+        );
+
+        let (merkle_path, leaf_index) = sim.get_merkle_path_and_index(&genesis_coin).unwrap();
+        let merkle_root = sim.get_merkle_root();
+        let serial_commitment = *genesis_coin.serial_commitment.as_bytes();
+        let coin_commitment = CoinCommitment::compute(
+            &genesis_coin.tail_hash,
+            genesis_coin.amount,
+            &genesis_coin.puzzle_hash,
+            &genesis_coin.serial_commitment,
+            clvm_zk::crypto_utils::hash_data_default,
+        );
+
+        let genesis = GenesisSpend {
+            serial_number: genesis_secrets.serial_number,
+            serial_randomness: genesis_secrets.serial_randomness,
+            puzzle_hash: genesis_coin.puzzle_hash,
+            amount: genesis_coin.amount,
+            tail_hash: genesis_coin.tail_hash,
+            serial_commitment,
+            coin_commitment: coin_commitment.0,
+            merkle_path,
+            merkle_root,
+            leaf_index: leaf_index as u64,
+        };
+
+        // first mint succeeds
+        let output_serial1 = rand_bytes();
+        let output_rand1 = rand_bytes();
+        let result1 = sim.mint_cat(
+            "(mod () 1)",
+            vec![],
+            hash_data(b"output_puzzle"),
+            "(mod () 1)",
+            100,
+            output_serial1,
+            output_rand1,
+            Some(genesis.clone()),
+        );
+        assert!(result1.is_ok(), "first mint should succeed");
+
+        // second mint with same genesis must fail — nullifier already used
+        let output_serial2 = rand_bytes();
+        let output_rand2 = rand_bytes();
+        let result2 = sim.mint_cat(
+            "(mod () 1)",
+            vec![],
+            hash_data(b"output_puzzle2"),
+            "(mod () 1)",
+            100,
+            output_serial2,
+            output_rand2,
+            Some(genesis),
+        );
+        assert!(result2.is_err(), "second mint with same genesis should fail");
+        // The error is that the genesis merkle proof is stale (root changed after first mint),
+        // OR the genesis nullifier was not checked at backend level (the simulator doesn't
+        // re-check nullifier against the genesis when calling the prover again — it would
+        // need a fresh merkle root). For proper prevention, the nullifier set check in the
+        // simulator is the correct enforcement point.
+        // This test documents the current behavior.
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Test 4: TAIL returns nil → Err
+    // ────────────────────────────────────────────────────────────
+    #[test]
+    fn test_mint_tail_nil_rejected() {
+        let backend = MockBackend::new().unwrap();
+        let output_serial = rand_bytes();
+        let output_rand = rand_bytes();
+        let input = build_mint_input("(mod () ())", output_serial, output_rand, None);
+
+        let result = backend.prove_with_input(input);
+        assert!(result.is_err(), "nil TAIL should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("nil"),
+            "error should mention nil: {}",
+            err
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Test 5: wrong tail_source (hash mismatch) → Err
+    // ────────────────────────────────────────────────────────────
+    #[test]
+    fn test_mint_tail_hash_mismatch() {
+        let backend = MockBackend::new().unwrap();
+        let output_serial = rand_bytes();
+        let output_rand = rand_bytes();
+
+        // compile the REAL tail to get its hash
+        let (_, real_tail_hash) =
+            compile_chialisp_to_bytecode(hash_data, "(mod () 1)").unwrap();
+
+        // build input with wrong tail_source but correct hash
+        let input = Input {
+            chialisp_source: "(mod () ())".to_string(),
+            program_parameters: vec![],
+            coin_mode: CoinMode::Mint(MintData {
+                tail_source: "(mod (x) x)".to_string(), // WRONG source
+                tail_params: vec![],
+                output_puzzle_hash: hash_data(b"output_puzzle"),
+                output_amount: 1000,
+                output_serial,
+                output_rand,
+                genesis_coin: None,
+            }),
+            tail_hash: Some(real_tail_hash), // real hash of (mod () 1)
+            tail_source: None,
+            tail_params: vec![],
+            additional_coins: None,
+        };
+
+        let result = backend.prove_with_input(input);
+        assert!(result.is_err(), "hash mismatch should be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("mismatch"),
+            "error should mention mismatch: {}",
+            err
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Test 6: mint then spend the minted coin in same simulator session
+    // ────────────────────────────────────────────────────────────
+    #[test]
+    fn test_mint_then_spend() {
+        let mut sim = CLVMZkSimulator::default();
+        let puzzle_source = "(mod () 1)";
+        let puzzle_hash = compile_chialisp_to_bytecode(
+            clvm_zk::crypto_utils::hash_data_default,
+            puzzle_source,
+        )
+        .unwrap()
+        .1;
+
+        let output_serial = rand_bytes();
+        let output_rand = rand_bytes();
+
+        // mint
+        let (coin_commitment, tail_hash) = sim
+            .mint_cat(
+                "(mod () 1)",
+                vec![],
+                puzzle_hash,
+                puzzle_source,
+                1000,
+                output_serial,
+                output_rand,
+                None,
+            )
+            .expect("mint should succeed");
+
+        assert_ne!(coin_commitment, [0u8; 32], "coin_commitment should be non-zero");
+
+        // build the PrivateCoin for spending
+        let serial_commitment_bytes =
+            compute_serial_commitment(clvm_zk::crypto_utils::hash_data_default, &output_serial, &output_rand);
+        let private_coin = clvm_zk::protocol::PrivateCoin::new_with_tail(
+            puzzle_hash,
+            1000,
+            SerialCommitment::from_bytes(serial_commitment_bytes),
+            tail_hash,
+        );
+        let secrets = CoinSecrets::new(output_serial, output_rand);
+
+        // spend it
+        let result = sim.spend_coins(vec![(private_coin, puzzle_source.to_string(), secrets)]);
+        assert!(result.is_ok(), "spending minted coin should succeed: {:?}", result.err());
+        assert_eq!(result.unwrap().nullifiers.len(), 1, "expected 1 nullifier");
+    }
+}


### PR DESCRIPTION
## Summary

- **CoinMode::Mint** implemented across all backends (mock, risc0, sp1) — was panic/error
- **compute_genesis_nullifier**: one-time-use genesis coin enforcement via `SHA256("clvm_zk_genesis_v1.0" || serial || tail_hash)` — prevents double-minting
- **compute_nullifier_v2** (ZK-01 fix): `SHA256("clvm_zk_nullifier_v2.0" || tail_hash || serial || program || amount)` — tail_hash binding prevents cross-asset nullifier collision attacks. v1 deprecated.
- **mint_cat** simulator method + **mint_command** CLI
- **CoinInfo.tail_source**: stored at mint, auto-retrieved at spend — CAT coins now spend correctly via `spend_coins`
- 6 new tests covering: unlimited TAIL, genesis nullifier, double-mint prevention, nil TAIL rejection, hash mismatch, mint-then-spend

## Files changed (13)
- `clvm_zk_core/src/lib.rs` — `compute_genesis_nullifier`, `compute_nullifier_v2`, v1 deprecated
- `backends/mock/src/backend.rs` — full Mint arm, enforce_ring_balance guard, v2 nullifier
- `backends/risc0/guest/src/main.rs` — Mint arm, v2 nullifier
- `backends/sp1/program/src/main.rs` — mirror risc0
- `backends/risc0/src/lib.rs`, `backends/sp1/src/lib.rs` — removed host-side Mint guards
- `backends/risc0/guest_settlement/src/main.rs`, `backends/sp1/program_settlement/src/main.rs` — v2 nullifier
- `src/lib.rs` — `ClvmZkProver::prove_with_input`
- `src/simulator.rs` — `mint_cat`, `CoinInfo.tail_source`, UTXO key fix, CAT spend tail_source lookup
- `src/cli.rs` — `SimAction::Mint`, `mint_command`
- `tests/test_cat_minting.rs` — 6 tests

## Test plan
- [x] `cargo test --no-default-features --features mock,testing --test test_cat_minting` — 6/6 pass
- [x] `cargo test --no-default-features --features mock,testing` — full suite green, no regressions